### PR TITLE
Release 2.31.0

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,0 @@
-example/ios/Pods
-lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 2.31.0 (January 2026)
 
-- [Update]: All release notes were migrated to [Developer center](https://github.com/vonage-technology/developer-center/blob/develop/src/documents/developer/sdks/react-native/release-notes.html.md)
+- [Update]: All release notes were migrated to [Developer center](https://developer.vonage.com/en/video/client-sdks/react-native/release-notes?source=video)
 
 - [Update]: This version adds a new `OTSession.forceDisconnect()` method for forcing clients to disconnect.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,6 @@
 # 2.31.0 (January 2026)
 
-- [Update]: This version now supports expo, now you can use expo plugin to configure user permissions for both platforms (see the [Installation section](./README.md#installation) of the README.md file).
-
-- [Update]: This version is built with the [React Native new architecture](https://reactnative.dev/architecture/landing-page). The only differences from previous versions are that you need to use a version of React Native that supports the new architecture (0.76+) and you need to register the Vonag React Native packages in your application (see the [Installation section](./README.md#installation) of the README.md file).
-
-- [Update]: This version updates the Vonage Video Android SDK and iOS SDK to version 2.31.1. For more information, see the [Android SDK release notes](https://tokbox.com/developer/sdks/android/release-notes.html) and the [iOS SDK release notes](https://tokbox.com/developer/sdks/ios/release-notes.html).
+- [Update]: All release notes were migrated to [Developer center](https://github.com/vonage-technology/developer-center/blob/develop/src/documents/developer/sdks/react-native/release-notes.html.md)
 
 - [Update]: This version adds a new `OTSession.forceDisconnect()` method for forcing clients to disconnect.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 2.31.0 (September 2025)
+# 2.31.0 (January 2026)
+
+- [Update]: This version now supports expo, now you can use expo plugin to configure user permissions for both platforms (see the [Installation section](./README.md#installation) of the README.md file).
 
 - [Update]: This version is built with the [React Native new architecture](https://reactnative.dev/architecture/landing-page). The only differences from previous versions are that you need to use a version of React Native that supports the new architecture (0.76+) and you need to register the OpenTok React Native packages in your application (see the [Installation section](./README.md#installation) of the README.md file).
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,73 @@ See the system requirements for the [OpenTok Android SDK](https://tokbox.com/dev
 
 ## Installation
 
+
+### For Expo projects
+
+If you're using Expo, the setup is simplified with the config plugin:
+
+1. Install the package:
+
+   ```bash
+   npx expo install opentok-react-native
+   ```
+
+2. Add the plugin to your `app.json` or `app.config.js`:
+
+   ```json
+   {
+     "expo": {
+       "plugins": [
+         [
+           "opentok-react-native",
+           {
+             "cameraPermission": "Allow $(PRODUCT_NAME) to use your camera for video calls",
+             "microphonePermission": "Allow $(PRODUCT_NAME) to use your microphone for audio calls"
+           }
+         ]
+       ]
+     }
+   }
+   ```
+
+   **Plugin iOS Configuration Options:**
+
+   | Option                 | Type   | Default                                                             | Description                                                      |
+   | ---------------------- | ------ | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+   | `cameraPermission`     | string | `"Allow $(PRODUCT_NAME) to access your camera for video calls"`     | iOS camera permission message (NSCameraUsageDescription)         |
+   | `microphonePermission` | string | `"Allow $(PRODUCT_NAME) to access your microphone for audio calls"` | iOS microphone permission message (NSMicrophoneUsageDescription) |
+
+3. Rebuild your app:
+
+   ```bash
+   npx expo prebuild
+   npx expo run:ios
+   # or
+   npx expo run:android
+   ```
+
+**What the config plugin does automatically:**
+
+- ✅ Adds iOS camera and microphone permissions to Info.plist
+- ✅ Adds all required Android permissions to AndroidManifest.xml:
+  - BLUETOOTH
+  - REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+  - BLUETOOTH_CONNECT
+  - BROADCAST_STICKY
+  - CAMERA
+  - INTERNET
+  - MODIFY_AUDIO_SETTINGS
+  - READ_PHONE_STATE
+  - RECORD_AUDIO
+  - ACCESS_NETWORK_STATE
+- ✅ Configures hardware features for Android
+
+**No manual native configuration needed!**
+
+---
+
+### For React Native CLI projects
+
 1. In your terminal, change into your React Native project's directory.
 
 2. Add the library using `npm` or `yarn`:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -101,7 +101,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android:0.78.0"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.vonage:client-sdk-video:2.30.1'
+  implementation 'com.vonage:client-sdk-video:2.31.0'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -57,6 +57,9 @@ class OTRNPublisher : FrameLayout, PublisherListener,
     fun updateProperties(props: ReactStylesDiffMap?) {
         if (this.props == null) {
             this.props = props?.toMap()
+            ?.filterValues { it != null }
+            ?.mapValues { it.value!! }
+            ?.toMutableMap()
             return
         }
     }

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -243,18 +243,21 @@ class OTRNPublisher : FrameLayout, PublisherListener,
                 .enableOpusDtx(this.props?.get("enableDtx") as Boolean)
                 .build()
             publisher?.setPublisherVideoType(PublisherKit.PublisherKitVideoType.PublisherKitVideoTypeCamera)
-            if (this.props?.get("cameraPosition") == "back") {
-                publisher?.cycleCamera()
-            }
             if (this.props?.get("videoTrack") as Boolean) {
                 publisher?.getCapturer()?.setVideoContentHint(
                     Utils.convertVideoContentHint(this.props?.get("videoContentHint") as String)
                 )
             }
+            if (this.props?.get("cameraPosition") as String == "back") {
+                // Do not set publishVideo here, start when stream is created
+                // to avoid front camera preview flash
+                publisher?.setPublishVideo(false)
+            } else {
+                publisher?.setPublishVideo(this.props?.get("publishVideo") as Boolean)
+            }
         }
 
         publisher?.setPublishAudio(this.props?.get("publishAudio") as Boolean)
-        publisher?.setPublishVideo(this.props?.get("publishVideo") as Boolean)
         publisher?.setPublishCaptions(this.props?.get("publishCaptions") as Boolean)
         publisher?.setStyle(
             BaseVideoRenderer.STYLE_VIDEO_SCALE,
@@ -295,10 +298,14 @@ class OTRNPublisher : FrameLayout, PublisherListener,
             this.addView(publisher?.view)
             requestLayout()
         }
-        props!!.clear() //we do not need to keep this around ?
     }
 
     override fun onStreamCreated(publisher: PublisherKit, stream: Stream) {
+        val cameraPosition = this.props?.get("cameraPosition") as? String ?: "front"
+        if (cameraPosition == "back") {
+            this.publisher?.cycleCamera()
+            this.publisher?.setPublishVideo(this.props?.get("publishVideo") as Boolean)
+        }
         val payload = EventUtils.prepareJSStreamMap(stream, publisher.getSession())
         emitOpenTokEvent("onStreamCreated", payload)
     }

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -63,6 +63,9 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
     fun updateProperties(props: ReactStylesDiffMap?) {
         if (this.props == null) {
             this.props = props?.toMap()
+            ?.filterValues { it != null }
+            ?.mapValues { it.value!! }
+            ?.toMutableMap()
         }
     }
 

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -69,11 +69,37 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
         }
     }
 
+    private fun findStream(streamId: String): Stream? {
+        // Check subscriberStreams (remote streams)
+        var stream = sharedState.getSubscriberStreams().get(streamId)
+        if (stream != null) return stream
+        
+        // Check publisher streams (your own published streams)
+        val publishers = sharedState.getPublishers()
+        for (publisher in publishers.values) {
+            if (publisher.stream?.streamId == streamId) {
+                return publisher.stream
+            }
+        }
+        return null
+    }
+
     override fun onAttachedToWindow() {
-        session = sharedState.getSessions().get(sessionId)
-        stream = sharedState.getSubscriberStreams().get(streamId)
         super.onAttachedToWindow()
-        subscribeToStream(session ?: return, stream ?: return)
+        
+        val safeSessionId = sessionId
+        val safeStreamId = streamId
+        
+        if (safeSessionId == null || safeStreamId == null) {
+            return
+        }
+        
+        session = sharedState.getSessions().get(safeSessionId)
+        stream = findStream(safeStreamId)
+
+        if (session != null && stream != null) {
+            subscribeToStream(session!!, stream!!)
+        }
     }
 
     private fun configureComponent() {

--- a/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
+++ b/android/src/main/java/com/opentokreactnative/OTScreenCapturer.java
@@ -64,7 +64,12 @@ public class OTScreenCapturer extends BaseVideoCapturer {
     };
 
     public OTScreenCapturer(View view) {
-        this.contentView = view;
+        View parentView = (View) view.getParent();
+        if (parentView != null) {
+            this.contentView = parentView; // Use ReactSurfaceView in a NewArchitecture
+        } else {
+            this.contentView = view; // Fallback
+        }
     }
 
     @Override

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,2 @@
+const plugin = require('./expo/build/index');
+module.exports = plugin.default || plugin;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  ignores: ['node_modules/', 'example/ios/Pods', 'lib/'],
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+};

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.BROADCAST_STICKY" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example/package.json
+++ b/example/package.json
@@ -10,20 +10,21 @@
     "build:ios": "react-native build-ios --scheme OpentokReactNativeExample --mode Debug --extra-params \"-sdk iphonesimulator CC=clang CPLUSPLUS=clang++ LD=clang LDPLUSPLUS=clang++ GCC_OPTIMIZATION_LEVEL=0 GCC_PRECOMPILE_PREFIX_HEADER=YES ASSETCATALOG_COMPILER_OPTIMIZATION=time DEBUG_INFORMATION_FORMAT=dwarf COMPILER_INDEX_STORE_ENABLE=NO\""
   },
   "dependencies": {
-    "react": "18.3.1",
-    "react-native": "0.77.0"
+    "react": "19.1.0",
+    "react-native": "0.81.1",
+    "react-native-safe-area-context": "^5.6.2"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.3",
     "@babel/runtime": "^7.25.0",
-    "@react-native-community/cli": "15.0.1",
-    "@react-native-community/cli-platform-android": "15.0.1",
-    "@react-native-community/cli-platform-ios": "15.0.1",
-    "@react-native/babel-preset": "0.77.0",
-    "@react-native/metro-config": "0.77.0",
-    "@react-native/typescript-config": "0.77.0",
-    "react-native-builder-bob": "^0.36.0"
+    "@react-native-community/cli": "20.0.1",
+    "@react-native-community/cli-platform-android": "20.0.1",
+    "@react-native-community/cli-platform-ios": "20.0.1",
+    "@react-native/babel-preset": "0.81.1",
+    "@react-native/metro-config": "^0.81.1",
+    "@react-native/typescript-config": "0.81.1",
+    "react-native-builder-bob": "^0.40.13"
   },
   "engines": {
     "node": ">=18"

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,11 +1,12 @@
 import React, { useRef, useEffect } from 'react';
-import { SafeAreaView, StyleSheet, Button } from 'react-native';
+import { StyleSheet, Button } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
   OTSession,
   OTSubscriber,
-  OTSubscriberView,
   OTPublisher,
+  type StreamCreatedEvent,
 } from 'opentok-react-native';
 
 function App(): React.JSX.Element {
@@ -19,13 +20,8 @@ function App(): React.JSX.Element {
   const [publishStream, setPublishStream] = React.useState<boolean>(true);
   const [subscribeToStreams, setSubscribeToStreams] =
     React.useState<boolean>(true);
-  const [streamProperties, setStreamProperties] = React.useState<Any>({});
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [maxVideoBitrate, setMaxVideoBitrate] = React.useState<number>(0);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [videoBitratePreset, setVideoBitratePreset] =
-    React.useState<string>('bw_saver');
-  const [signalProp, setSignalProp] = React.useState<Any>({
+  const [streamProperties, setStreamProperties] = React.useState<any>({});
+  const [signalProp, setSignalProp] = React.useState<any>({
     type: 'greeting2',
     data: 'initial signal from React Native',
   });
@@ -37,7 +33,6 @@ function App(): React.JSX.Element {
     setSubscribeToVideo((val) => !val);
   };
   const logAllEvents = false;
-  const useIndividualSubscriberViews = false;
   const subscribeToSelf = false;
   const useStreamProperties = false;
 
@@ -50,7 +45,7 @@ function App(): React.JSX.Element {
   };
 
   useEffect(() => {
-    // console.log('streamProperties updated to:', streamProperties);
+    console.log('streamProperties updated to:', streamProperties);
   }, [streamProperties]);
 
   return (
@@ -60,12 +55,6 @@ function App(): React.JSX.Element {
         token={token}
         sessionId={sessionId}
         ref={sessionRef}
-        options={
-          {
-            // connectionEventsSuppressed: false,
-            // enableSinglePeerConnection: true,
-          }
-        }
         eventHandlers={{
           sessionConnected: (event: any) => {
             console.log('sessionConnected', event);
@@ -98,17 +87,11 @@ function App(): React.JSX.Element {
                 type: 'greeting2',
                 data: 'another signal from React Native (via prop)',
               });
-              /*
-              sessionRef.current
-                ?.forceMuteAll([])
-                .then(() => console.log('forceMuteAll success'))
-                .catch((e) => console.log('forceMuteAll error', e));
-              */
             }, 1000);
           },
           streamCreated: (event: any) => {
             console.log('streamCreated', event);
-            setStreamProperties((prevObject: Any) => ({
+            setStreamProperties((prevObject: any) => ({
               ...prevObject,
               [event.streamId]: {
                 subscribeToAudio: true,
@@ -121,14 +104,6 @@ function App(): React.JSX.Element {
                 audioVolume: 0.1,
               },
             }));
-            /*
-            sessionRef.current
-              ?.forceMuteStream(event.streamId)
-              .then(() =>
-                console.log('forceMuteStream success - stream', event.streamId)
-              )
-              .catch((e) => console.log('forceMuteStream error', e));
-            */
           },
           streamDestroyed: (event: any) =>
             console.log('streamDestroyed', event),
@@ -136,9 +111,6 @@ function App(): React.JSX.Element {
           error: (event: any) => console.log('error event', event),
           connectionCreated: (event: any) => {
             console.log('connectionCreated', event);
-            setTimeout(() => {
-              // sessionRef.current?.forceDisconnect(event.connectionId);
-            }, 5000);
             sessionRef.current?.signal({
               to: event.connectionId,
               data: `wecome to the session, connection ${event.connectionId}`,
@@ -160,50 +132,29 @@ function App(): React.JSX.Element {
       >
         {publishStream ? (
           <OTPublisher
-            sessionId={sessionId}
             key="publisher"
             ref={publisherRef}
             properties={{
               publishVideo: subscribeToVideo,
               publishAudio: subscribeToVideo,
               allowAudioCaptureWhileMuted: true,
-              // cameraZoomFactor: 2,
-              // cameraTorch: false,
-              // videoTrack: true,
-              // audioTrack: false,
-              // audioBitrate: 8000,
-              // enableDtx: true,
               name: 'OTRN',
-              // videoContentHint: 'text',
-              // maxVideoBitrate,
-              // videoBitratePreset,
             }}
             eventHandlers={{
-              error: (event: any) => console.log('pub error', event),
-              streamCreated: (event: any) => {
+              error: (event: any) => {
+                console.log('pub error', event);
+              },
+              streamCreated: (event: StreamCreatedEvent) => {
                 console.log('pub streamCreated', event);
                 setTimeout(() => {
-                  // publisherRef.current?.getRtcStatsReport();
-                  setMaxVideoBitrate(2000000);
-                  setVideoBitratePreset('extra_bw_saver');
                   publisherRef.current?.getRtcStatsReport();
                 }, 5000);
-                /*
-                sessionRef.current
-                  ?.forceMuteAll([event.streamId])
-                  .then(() =>
-                    console.log(
-                      'forcemuteAll success - excluded stream',
-                      event.streamId
-                    )
-                  )
-                  .catch((e) => console.log('forcemuteAll error', e));
-                */
               },
-              streamDestroyed: (event: any) =>
-                console.log('pub streamDestroyed', event),
-              audioLevel: (event: any) => {
-                logAllEvents && console.log('pub audioLevel', event);
+              streamDestroyed: (event: any) => {
+                console.log('pub streamDestroyed', event);
+              },
+              audioLevel: (level: number) => {
+                logAllEvents && console.log('pub audioLevel', level);
               },
               audioNetworkStats: (event: any) => {
                 logAllEvents && console.log('pub audioNetworkStats', event);
@@ -214,11 +165,11 @@ function App(): React.JSX.Element {
               videoDisabled: (event: any) => {
                 console.log('pub videoDisabled', event);
               },
-              videoDisableWarning: (event: any) => {
-                console.log('pub videoDisableWarning', event);
+              videoDisableWarning: () => {
+                console.log('pub videoDisableWarning');
               },
-              videoDisableWarningLifted: (event: any) => {
-                console.log('pub videoDisableWarningLifted', event);
+              videoDisableWarningLifted: () => {
+                console.log('pub videoDisableWarningLifted');
               },
               videoEnabled: (event: any) => {
                 console.log('pub videoEnabled', event);
@@ -239,9 +190,6 @@ function App(): React.JSX.Element {
             properties={{
               subscribeToAudio: subscribeToVideo,
               subscribeToVideo,
-              // subscribeToCaptions: true,
-              // preferredFrameRate: 444,
-              // audioVolume: 0.2,
             }}
             ref={subscriberRef}
             streamProperties={
@@ -257,8 +205,8 @@ function App(): React.JSX.Element {
               captionReceived: (event: any) => {
                 console.log('sub captionReceived', event);
               },
-              disconnected: (event: any) => {
-                console.log('sub disconnected', event);
+              disconnected: () => {
+                console.log('sub disconnected');
               },
               error: (event: any) => {
                 console.log('sub error', event);
@@ -266,23 +214,17 @@ function App(): React.JSX.Element {
               rtcStatsReport: (event: any) => {
                 logAllEvents && console.log('sub rtcStatsReport', event);
               },
-              subscriberConnected: (event: any) => {
-                console.log('subscriberConnected', event);
-                setTimeout(() => {
-                  subscriberRef.current?.getRtcStatsReport();
-                }, 4000);
-              },
-              videoDataReceived: (event: any) => {
-                logAllEvents && console.log('sub videoDataReceived', event);
+              videoDataReceived: () => {
+                logAllEvents && console.log('sub videoDataReceived');
               },
               videoDisabled: (event: any) => {
                 console.log('sub videoDisabled', event);
               },
-              videoDisableWarning: (event: any) => {
-                console.log('sub videoDisableWarning', event);
+              videoDisableWarning: () => {
+                console.log('sub videoDisableWarning');
               },
-              videoDisableWarningLifted: (event: any) => {
-                console.log('sub videoDisableWarningLifted', event);
+              videoDisableWarningLifted: () => {
+                console.log('sub videoDisableWarningLifted');
               },
               videoEnabled: (event: any) => {
                 console.log('sub videoEnabled', event);
@@ -291,24 +233,7 @@ function App(): React.JSX.Element {
                 logAllEvents && console.log('sub videoNetworkStats', event);
               },
             }}
-          >
-            {useIndividualSubscriberViews
-              ? (streamIds) => {
-                  if (streamIds.length === 0) {
-                    return null;
-                  }
-                  return streamIds.map((streamId) => {
-                    return (
-                      <OTSubscriberView
-                        streamId={streamId}
-                        key={streamId}
-                        style={styles.videoview}
-                      />
-                    );
-                  });
-                }
-              : null}
-          </OTSubscriber>
+          ></OTSubscriber>
         ) : null}
       </OTSession>
       {sessionId2 ? (

--- a/expo/index.ts
+++ b/expo/index.ts
@@ -1,0 +1,99 @@
+import {
+  type ConfigPlugin,
+  withAndroidManifest,
+  withInfoPlist,
+  AndroidConfig,
+  withPlugins,
+} from '@expo/config-plugins';
+
+export interface OpentokPluginiOSProps {
+  /**
+   * iOS camera permission message
+   * @default 'Allow $(PRODUCT_NAME) to access your camera for video calls'
+   */
+  cameraPermission?: string;
+  /**
+   * iOS microphone permission message
+   * @default 'Allow $(PRODUCT_NAME) to access your microphone for audio calls'
+   */
+  microphonePermission?: string;
+}
+
+/**
+ * Add iOS Info.plist entries for camera and microphone permissions
+ */
+const withIosPermissions: ConfigPlugin<OpentokPluginiOSProps> = (
+  config,
+  props
+) => {
+  const {
+    cameraPermission = 'Allow $(PRODUCT_NAME) to access your camera for video calls',
+    microphonePermission = 'Allow $(PRODUCT_NAME) to access your microphone for audio calls',
+  } = props;
+
+  return withInfoPlist(config, (config) => {
+    config.modResults.NSCameraUsageDescription = cameraPermission;
+    config.modResults.NSMicrophoneUsageDescription = microphonePermission;
+    return config;
+  });
+};
+
+/**
+ * Add Android permissions to AndroidManifest.xml
+ */
+const withAndroidPermissions: ConfigPlugin = (config) => {
+  return withAndroidManifest(config, (config) => {
+    const permissions = [
+      'android.permission.BLUETOOTH',
+      'android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS',
+      'android.permission.BLUETOOTH_CONNECT',
+      'android.permission.BROADCAST_STICKY',
+      'android.permission.CAMERA',
+      'android.permission.INTERNET',
+      'android.permission.MODIFY_AUDIO_SETTINGS',
+      'android.permission.READ_PHONE_STATE',
+      'android.permission.RECORD_AUDIO',
+      'android.permission.ACCESS_NETWORK_STATE',
+    ];
+
+    permissions.forEach((permission) => {
+      AndroidConfig.Permissions.addPermission(config.modResults, permission);
+    });
+
+    // Add hardware feature for camera (non-required)
+    if (!config.modResults.manifest['uses-feature']) {
+      config.modResults.manifest['uses-feature'] = [];
+    }
+
+    const cameraFeatureExists = config.modResults.manifest['uses-feature'].some(
+      (feature: any) => feature.$['android:name'] === 'android.hardware.camera'
+    );
+
+    if (!cameraFeatureExists) {
+      config.modResults.manifest['uses-feature'].push({
+        $: {
+          'android:name': 'android.hardware.camera',
+          'android:required': 'false',
+        },
+      });
+    }
+
+    return config;
+  });
+};
+
+/**
+ * Main Expo Config Plugin for opentok-react-native
+ * Automatically configures native permissions and dependencies
+ */
+const withOpentok: ConfigPlugin<OpentokPluginiOSProps> = (
+  config,
+  props = {}
+) => {
+  return withPlugins(config, [
+    [withIosPermissions, props],
+    withAndroidPermissions,
+  ]);
+};
+
+export default withOpentok;

--- a/expo/tsconfig.json
+++ b/expo/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./build",
+    "rootDir": "./",
+    "declaration": true,
+    "declarationMap": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true
+  },
+  "include": ["index.ts"],
+  "exclude": ["node_modules", "build"]
+}

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -118,8 +118,11 @@ using namespace facebook::react;
     }
 
     if (oldViewProps.scaleBehavior != newViewProps.scaleBehavior) {
-        NSLog(@"Setting scale behavior to %@", RCTNSStringFromString(newViewProps.scaleBehavior));
         [_impl setScaleBehavior:RCTNSStringFromString(newViewProps.scaleBehavior)];
+    }
+
+    if (oldViewProps.cameraPosition != newViewProps.cameraPosition) {
+        [_impl setCameraPosition:RCTNSStringFromString(newViewProps.cameraPosition)];
     }
 
     [super updateProps:props oldProps:oldProps];

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -409,8 +409,8 @@ import React
             publisher.audioLevelDelegate = nil
             publisher.networkStatsDelegate = nil
             publisher.rtcStatsReportDelegate = nil
-            OTRN.sharedState.publishers[publisherId] = nil
-            OTRN.sharedState.isPublishing[publisherId] = nil
+            OTRN.sharedState.publishers.removeValue(forKey: publisherId)
+            OTRN.sharedState.isPublishing.removeValue(forKey: publisherId)
             self.publisherId = ""
             self.sessionId = ""
             self.currentSession = nil
@@ -480,6 +480,7 @@ private class PublisherDelegateHandler: NSObject, OTPublisherKitDelegate {
             )
             streamInfo["publisherId"] = publisherId
             OTRN.sharedState.publishers[publisherId] = nil
+            OTRN.sharedState.publishers.removeValue(forKey: publisherId)
             impl?.strictUIViewContainer?.handleStreamDestroyed(streamInfo)
         }
     }

--- a/ios/OTRNPublisherComponentView.swift
+++ b/ios/OTRNPublisherComponentView.swift
@@ -128,8 +128,7 @@ import React
             publisher.videoType = .screen
             publisher.videoCapture = OTScreenCapture(view: screenView)
         } else if let cameraPosition = properties["cameraPosition"] as? String {
-            publisher.cameraPosition =
-                cameraPosition == "front" ? .front : .back
+            publisher.cameraPosition = cameraPosition.toCameraPosition
         }
 
         publisher.cameraTorch = Utils.sanitizeBooleanProperty(
@@ -340,6 +339,25 @@ import React
             return
         }
         publisher.viewScaleBehavior = scaleBehavior.toViewScaleBehavior
+    }
+
+    @objc public func setCameraPosition(_ cameraPosition: String) {
+        guard let publisherId = self.publisherId else {
+            strictUIViewContainer?.handleError([
+                "code": OTPublisherError,
+                "message": "Publisher ID is not set",
+            ])
+            return
+        }
+
+        guard let publisher = OTRN.sharedState.publishers[publisherId] else {
+            strictUIViewContainer?.handleError([
+                "code": OTPublisherError,
+                "message": "Could not find publisher instance",
+            ])
+            return
+        }
+        publisher.cameraPosition = cameraPosition.toCameraPosition
     }
 
     @objc public func cleanup() {

--- a/ios/OpentokReactNative.swift
+++ b/ios/OpentokReactNative.swift
@@ -232,7 +232,6 @@ import React
         }
 
         session.unpublish(publisher, error: &error)
-        OTRN.sharedState.publishers.removeValue(forKey: publisherId)
     }
 
     @objc public func removeSubscriber(_ sessionId: String, streamId: String) {
@@ -247,7 +246,6 @@ import React
         }
 
         session.unsubscribe(subscriber, error: &error)
-        OTRN.sharedState.subscribers.removeValue(forKey: streamId)
     }
 
     @objc public func forceMuteAll(
@@ -488,6 +486,7 @@ private class SessionDelegateHandler: NSObject, OTSessionDelegate {
         let streamInfo: [String: Any] = EventUtils.prepareJSStreamEventData(
             stream)
         OTRN.sharedState.subscriberStreams.removeValue(forKey: stream.streamId)
+        OTRN.sharedState.subscribers.removeValue(forKey: stream.streamId)
         impl?.ot?.emit(onStreamDestroyed: streamInfo)
     }
 

--- a/ios/Utils/Utils.swift
+++ b/ios/Utils/Utils.swift
@@ -329,3 +329,16 @@ extension String {
         }
     }
 }
+
+extension String {
+    var toCameraPosition: AVCaptureDevice.Position {
+        switch self {
+        case "front":
+            return .front
+        case "back":
+            return .back
+        default:
+            return .back
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "*.podspec",
     "app.plugin.js",
     "react-native.config.js",
+    "tsconfig.build.json",
+    "tsconfig.json",
     "expo",
     "!expo/node_modules",
     "!expo/tsconfig.json",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "axios": "^1.6.8",
+    "axios": "^1.13.2",
     "deprecated-react-native-prop-types": "5.0.0",
     "react-native-uuid": "^2.0.3",
     "underscore": "^1.13.7"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint-fix": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build",
+    "prepare": "bob build && cp -R android/generated/java/com/facebook/react/viewmanagers/* android/src/main/java/com/facebook/react/viewmanagers/",
     "release": "release-it"
   },
   "keywords": [
@@ -71,29 +71,31 @@
     "underscore": "^1.13.7"
   },
   "devDependencies": {
-    "@commitlint/config-conventional": "^17.0.2",
-    "@react-native-community/cli": "15.0.1",
-    "@react-native/eslint-config": "^0.73.1",
-    "@release-it/conventional-changelog": "^9.0.2",
-    "@types/jest": "^29.5.5",
-    "@types/react": "^18.2.44",
-    "commitlint": "^17.0.2",
-    "del-cli": "^5.1.0",
-    "eslint": "^8.51.0",
-    "eslint-config-prettier": "^9.0.0",
-    "eslint-plugin-prettier": "^5.0.1",
+    "@commitlint/config-conventional": "^19.8.1",
+    "@eslint/compat": "^1.3.2",
+    "@eslint/eslintrc": "^3.3.1",
+    "@eslint/js": "^9.35.0",
+    "@evilmartians/lefthook": "^1.12.3",
+    "@react-native-community/cli": "20.0.1",
+    "@react-native/babel-preset": "0.81.1",
+    "@react-native/eslint-config": "^0.81.1",
+    "@release-it/conventional-changelog": "^10.0.1",
+    "@types/jest": "^29.5.14",
+    "@types/react": "^19.1.0",
+    "@typescript-eslint/parser": "^8.46.3",
+    "commitlint": "^19.8.1",
+    "del-cli": "^6.0.0",
+    "eslint": "^9.35.0",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",
-    "metro-react-native-babel-preset": "^0.77.0",
-    "prettier": "^3.0.3",
-    "react": "18.3.1",
-    "react-native": "0.77.0",
-    "react-native-builder-bob": "^0.36.0",
-    "release-it": "^17.10.0",
-    "turbo": "^1.10.7",
-    "typescript": "^5.2.2"
-  },
-  "resolutions": {
-    "@types/react": "^18.2.44"
+    "prettier": "^3.6.2",
+    "react": "19.1.0",
+    "react-native": "0.81.1",
+    "react-native-builder-bob": "^0.40.14",
+    "release-it": "^19.0.4",
+    "turbo": "^2.5.6",
+    "typescript": "^5.9.2"
   },
   "peerDependencies": {
     "react": "*",
@@ -184,8 +186,7 @@
       [
         "typescript",
         {
-          "project": "tsconfig.build.json",
-          "esm": true
+          "project": "tsconfig.build.json"
         }
       ]
     ]
@@ -207,6 +208,6 @@
   "create-react-native-library": {
     "type": "turbo-module",
     "languages": "kotlin-objc",
-    "version": "0.47.0"
+    "version": "0.54.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vonage/client-sdk-video-react-native",
-  "version": "2.31.0-beta.2",
+  "version": "2.31.0",
   "description": "Vonage Video client SDK for React Native",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "module": "./lib/module/index.js",
   "exports": {
     ".": {
+      "node": "./app.plugin.js",
       "import": {
         "types": "./lib/typescript/module/src/index.d.ts",
         "default": "./lib/module/index.js"
@@ -17,6 +18,10 @@
       }
     }
   },
+  "app.plugin": "./app.plugin.js",
+  "expo": {
+    "plugin": "./app.plugin.js"
+  },
   "files": [
     "src",
     "lib",
@@ -24,7 +29,11 @@
     "ios",
     "cpp",
     "*.podspec",
+    "app.plugin.js",
     "react-native.config.js",
+    "expo",
+    "!expo/node_modules",
+    "!expo/tsconfig.json",
     "!ios/build",
     "!android/build",
     "!android/gradle",
@@ -43,7 +52,8 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "lint-fix": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build && cp -R android/generated/java/com/facebook/react/viewmanagers/* android/src/main/java/com/facebook/react/viewmanagers/",
+    "prepare": "bob build && build:expo && mkdir -p android/src/main/java/com/facebook/react/viewmanagers && cp -R android/generated/java/com/facebook/react/viewmanagers/* android/src/main/java/com/facebook/react/viewmanagers/ || true",
+    "build:expo": "tsc --project expo/tsconfig.json",
     "release": "release-it"
   },
   "keywords": [
@@ -76,6 +86,7 @@
     "@eslint/eslintrc": "^3.3.1",
     "@eslint/js": "^9.35.0",
     "@evilmartians/lefthook": "^1.12.3",
+    "@expo/config-plugins": "^54.0.4",
     "@react-native-community/cli": "20.0.1",
     "@react-native/babel-preset": "0.81.1",
     "@react-native/eslint-config": "^0.81.1",

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -116,11 +116,14 @@ export default class OTPublisher extends React.Component {
         .catch((error) => {
           // this.otrnEventHandler(error);
         });
-    } else if (this.context && isConnected(this.context.sessionId)) {
-      setTimeout(
-        () => OT.publish(this.context.sessionId, this.state.publisherId),
-        100
-      );
+    } else {
+      // Context and publisherId might not be available immediately
+      // So we delay the publish call slightly
+      setTimeout(() => {
+        if (this.context && isConnected(this.context.sessionId)) {
+          OT.publish(this.context.sessionId, this.state.publisherId);
+        }
+      }, 100);
     }
   };
 

--- a/src/OTPublisher.js
+++ b/src/OTPublisher.js
@@ -11,6 +11,7 @@ import {
   removeEventListener,
   dispatchEvent,
   isConnected,
+  getPublisherStream,
 } from './helpers/OTSessionHelper';
 import { sanitizeProperties } from './helpers/OTPublisherHelper';
 import OTContext from './contexts/OTContext';
@@ -133,6 +134,16 @@ export default class OTPublisher extends React.Component {
 
   componentWillUnmount() {
     OT.unpublish(this.context.sessionId, this.state.publisherId);
+    const publisherStreamId = getPublisherStream(this.context.sessionId);
+    if (publisherStreamId) {
+      const event = {
+        streamId: publisherStreamId,
+        nativeEvent: {
+          streamId: publisherStreamId,
+        },
+      };
+      this.onStreamDestroyed(event);
+    }
     removeEventListener(
       this.context.sessionId,
       'sessionConnected',
@@ -140,10 +151,15 @@ export default class OTPublisher extends React.Component {
     );
   }
 
-  getPrePermissionViewStyle = (props) => ({
+  getPrePermissionViewStyle = () => ({
     backgroundColor: '#000',
     ...this.props.style,
   });
+
+  onStreamDestroyed = (event) => {
+    dispatchEvent(this.context.sessionId, 'publisherStreamDestroyed', event);
+    this.props.eventHandlers?.streamDestroyed?.(event.nativeEvent);
+  };
 
   render() {
     return this.state.permissionsGranted && this.state.componentMounted ? (
@@ -161,14 +177,7 @@ export default class OTPublisher extends React.Component {
           );
           this.props.eventHandlers?.streamCreated?.(event.nativeEvent);
         }}
-        onStreamDestroyed={(event) => {
-          dispatchEvent(
-            this.context.sessionId,
-            'publisherStreamDestroyed',
-            event
-          );
-          this.props.eventHandlers?.streamDestroyed?.(event.nativeEvent);
-        }}
+        onStreamDestroyed={this.onStreamDestroyed}
         onAudioLevel={(event) => {
           this.props.eventHandlers?.audioLevel?.(event.nativeEvent);
         }}

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -52,6 +52,7 @@ export default class OTSubscriber extends Component {
       this.publisherStreamCreatedHandler
     );
     addEventListener(
+      this.context.sessionId,
       'publisherStreamDestroyed',
       this.publisherStreamDestroyedHandler
     );

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -21,14 +21,14 @@ const getLog = (apiKey, sessionId, action, connectionId) => {
   const body = {
     payload: {
       platform: Platform.OS,
-      otrn_version: require('../../package.json').version,
+      otrn_version: require('../../../package.json').version,
       platform_version: Platform.Version,
     },
     payload_type: 'info',
     action,
     partner_id: apiKey,
     session_id: sessionId,
-    source: require('../../package.json').repository.url,
+    source: require('../../../package.json').repository.url,
   };
   if (connectionId) {
     body.connectionId = connectionId;

--- a/src/helpers/OTHelper.js
+++ b/src/helpers/OTHelper.js
@@ -21,14 +21,14 @@ const getLog = (apiKey, sessionId, action, connectionId) => {
   const body = {
     payload: {
       platform: Platform.OS,
-      otrn_version: require('../../../package.json').version,
+      otrn_version: require('../../package.json').version,
       platform_version: Platform.Version,
     },
     payload_type: 'info',
     action,
     partner_id: apiKey,
     session_id: sessionId,
-    source: require('../../../package.json').repository.url,
+    source: require('../../package.json').repository.url,
   };
   if (connectionId) {
     body.connectionId = connectionId;

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -42,6 +42,10 @@ const removeStream = (sessionId, streamId) => {
 
 const clearStreams = (sessionId) => {
   streams[sessionId] = [];
+  clearPublisherStream(sessionId);
+};
+
+const clearPublisherStream = (sessionId) => {
   publisherStreams[sessionId] = undefined;
 };
 

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -42,6 +42,7 @@ const removeStream = (sessionId, streamId) => {
 
 const clearStreams = (sessionId) => {
   streams[sessionId] = [];
+  publisherStreams[sessionId] = undefined;
 };
 
 const getStreams = (sessionId) => streams[sessionId] || [];


### PR DESCRIPTION
This pull request primarily updates documentation and references to reflect Vonage branding, update URLs to the latest Vonage developer site, and clarify feature descriptions and SDK usage. It also introduces a new beta version and deprecates the use of `apiKey` in favor of `applicationId` for session initialization. Additionally, it updates repository references for sample checkout in CI workflows.

**Documentation and Branding Updates:**

* Updated all references from OpenTok to Vonage in the `CHANGELOG.md`, including SDK names, feature descriptions, and permission notes to ensure consistency with Vonage branding. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL150-R173) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL178-R217)
* Replaced all legacy `tokbox.com` documentation and release note URLs with the corresponding `developer.vonage.com` links throughout the changelog, ensuring users are directed to the latest documentation. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR21-R35) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL50-R72) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL98-R122) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL150-R173) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL178-R217)

**Feature and Versioning Updates:**

* Added changelog entry for version `2.31.0-beta.0`, a pre-release supporting the React Native new architecture, with a note to consult the README for beta details.
* Documented the new `OTSession` prop: `applicationId`, which replaces the now-deprecated `apiKey` prop, and provided usage guidance for developers migrating to the new prop.

**CI/Workflow Updates:**

* Updated the GitHub Actions workflow to check out sample code from the new `Vonage/vonage-video-react-native-sdk-samples` repository instead of the old OpenTok samples repository.
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
This pull request introduces Expo support, updates dependencies, and improves both documentation and Android native code for the Vonage React Native SDK. The most notable changes are the addition of an Expo config plugin for easier integration, updates to the example app for compatibility with the latest React Native, and several bug fixes and improvements to Android publisher/subscriber logic.

**Expo Support and Documentation:**
- Added Expo config plugin and updated documentation to describe Expo setup, including automatic permission configuration for both Android and iOS. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R39-R105) [[2]](diffhunk://#diff-30c96ffcff1896ac43dd419c960f8da44a90102bb351125c0fddd58d9b9a4c9aR1-R2)

**Dependency and Example App Updates:**
- Upgraded example app dependencies to React Native 0.81.1 and React 19.1.0, added `react-native-safe-area-context`, and updated related dev dependencies for compatibility. [[1]](diffhunk://#diff-a593fc14fdef41aaf092f774b92cb74bafeda3e9559f8ae4762374bf4af80c92L13-R27) [[2]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L2-R9)
- Updated example app code to use new dependencies and simplified code by removing unused variables and improving event logging. [[1]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L22-R24) [[2]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L40) [[3]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L53-R48) [[4]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L63-L68) [[5]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L101-R94) [[6]](diffhunk://#diff-6a99c076036be89e153c671ac5e086623e32b13dfa5a46df98293d472c422010L124-L141)

**Android Native Improvements and Bug Fixes:**
- Improved publisher camera switching logic to prevent front camera preview flash and fixed property handling for null values. [[1]](diffhunk://#diff-cdb71b2bb1494383cafc1a34f697cde6d3be55d8d4146184cd239ee55e8647c2R60-R62) [[2]](diffhunk://#diff-cdb71b2bb1494383cafc1a34f697cde6d3be55d8d4146184cd239ee55e8647c2L243-L254) [[3]](diffhunk://#diff-cdb71b2bb1494383cafc1a34f697cde6d3be55d8d4146184cd239ee55e8647c2L295-R308)
- Enhanced subscriber logic to allow subscribing to both remote and local (published) streams, improving reliability in various session scenarios.
- Fixed screen capturer to use the correct parent view in New Architecture setups, ensuring compatibility with React Native's new rendering system.

**Changelog and Configuration Updates:**
- Updated `CHANGELOG.md` to reflect Expo support, corrected SDK naming, and clarified Android permissions. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL1-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL62-R64)
- Added new `eslint.config.js` and removed `.eslintignore` in favor of centralized ignore configuration. [[1]](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839R1-R12) [[2]](diffhunk://#diff-a0fdacd2ade87c5238dde44378f574f7e123e669acdf8b740878b14b33b20275L1-L2)

**Other Updates:**
- Updated Android example manifest and Gradle wrapper for compatibility with latest tooling. [[1]](diffhunk://#diff-8fc083d75c4d06482dc1ee1c9ba3edab0192a99add6fa96679b6ed189a049c88R7) [[2]](diffhunk://#diff-33c9d420f392affbc15e8f6d9c82c03f20fb6498eddce1843e70285f041c327dL3-R3)