### PR TITLE
Issue 947

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
+++ b/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
@@ -146,6 +146,9 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
     public void sendSignal(String sessionId, String type, String data, String to) {
         ConcurrentHashMap<String, Session> mSessions = sharedState.getSessions();
         Session mSession = mSessions.get(sessionId);
+        if (mSession == null) {
+            return;
+        }
         String connectionId = to;
         if (connectionId == null || connectionId.equals("")) {
             mSession.sendSignal(type, data);

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -312,6 +312,21 @@ using namespace facebook::react;
     }
 }
 
+- (void)handleReconnected:(NSDictionary *)eventData {
+    NSDictionary *streamDict = eventData[@"stream"];
+
+    auto eventEmitter = [self getEventEmitter];
+    if (eventEmitter) {
+        OTRNSubscriberEventEmitter::OnReconnected payload{
+            .stream = makeStreamStruct<
+                OTRNSubscriberEventEmitter::OnReconnectedStream,
+                OTRNSubscriberEventEmitter::OnReconnectedStreamConnection
+            >(streamDict)
+        };
+        eventEmitter->onReconnected(std::move(payload));
+    }
+}
+
 - (void)handleCaptionReceived:(NSDictionary *)eventData {
     NSDictionary *streamDict = eventData[@"stream"];
     NSString *text = eventData[@"text"] ? [eventData[@"text"] description] : @"";

--- a/ios/Utils/EventUtils.swift
+++ b/ios/Utils/EventUtils.swift
@@ -38,7 +38,7 @@ class EventUtils {
     
     static func prepareJSErrorEventData(_ error: OTError) -> Dictionary<String, Any> {
         var errorInfo: Dictionary<String, Any> = [:];
-        errorInfo["code"] = error.code;
+        errorInfo["code"] = String(error.code);
         errorInfo["message"] = error.localizedDescription;
         return errorInfo;
     }

--- a/package.json
+++ b/package.json
@@ -78,9 +78,6 @@
     "url": "https://github.com/opentok/opentok-react-native/issues"
   },
   "homepage": "https://developer.vonage.com/en/video/overview",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
   "dependencies": {
     "axios": "^1.13.2",
     "deprecated-react-native-prop-types": "5.0.0",

--- a/src/OTSubscriberNativeComponent.ts
+++ b/src/OTSubscriberNativeComponent.ts
@@ -90,6 +90,7 @@ export interface NativeProps extends ViewProps {
   onVideoDisableWarningLifted?: BubblingEventHandler<StreamEvent> | null;
   onVideoEnabled?: BubblingEventHandler<VideoEnabledEvent> | null;
   onVideoNetworkStats?: BubblingEventHandler<SubscriberVideoNetworkStatsEvent> | null;
+  onReconnected?: BubblingEventHandler<StreamEvent> | null;
 }
 
 export default codegenNativeComponent<NativeProps>(

--- a/src/OTSubscriberView.js
+++ b/src/OTSubscriberView.js
@@ -85,7 +85,10 @@ export default class OTSubscriberView extends React.Component {
           eventHandlers.audioNetworkStats?.(event.nativeEvent);
         }}
         onSubscriberConnected={(event) => {
-          eventHandlers.subscriberConnected?.(event.nativeEvent);
+          eventHandlers.connected?.(event.nativeEvent);
+        }}
+        onSubscriberDisconnected={(event) => {
+          eventHandlers.disconnected?.(event.nativeEvent);
         }}
         onRtcStatsReport={(event) => {
           eventHandlers.rtcStatsReport?.(event.nativeEvent);
@@ -93,8 +96,23 @@ export default class OTSubscriberView extends React.Component {
         onVideoEnabled={(event) => {
           eventHandlers.videoEnabled?.(event.nativeEvent);
         }}
+        onVideoDisabled={(event) => {
+          eventHandlers.videoDisabled?.(event.nativeEvent);
+        }}
         onVideoNetworkStats={(event) => {
           eventHandlers.videoNetworkStats?.(event.nativeEvent);
+        }}
+        onSubscriberError={(event) => {
+          eventHandlers.error?.(event.nativeEvent);
+        }}
+        onCaptionReceived={(event) => {
+          eventHandlers.captionReceived?.(event.nativeEvent);
+        }}
+        onVideoDisableWarning={(event) => {
+          eventHandlers.videoDisableWarning?.(event.nativeEvent);
+        }}
+        onVideoDisableWarningLifted={(event) => {
+          eventHandlers.videoDisableWarningLifted?.(event.nativeEvent);
         }}
         style={style}
       />

--- a/src/OTSubscriberView.js
+++ b/src/OTSubscriberView.js
@@ -114,6 +114,9 @@ export default class OTSubscriberView extends React.Component {
         onVideoDisableWarningLifted={(event) => {
           eventHandlers.videoDisableWarningLifted?.(event.nativeEvent);
         }}
+        onReconnected={(event) => {
+          eventHandlers.reconnected?.(event.nativeEvent);
+        }}
         style={style}
       />
     );


### PR DESCRIPTION
<!---
Thanks for sharing your code back to this repository. But before you continue, please make
sure that you have followed the Contribution Guidelines which can be found here:
https://github.com/opentok/opentok-react-native/blob/master/CONTRIBUTING.md
--->
### Contributing checklist
- [x] Code must follow existing styling conventions
- [x] Added a descriptive commit message
- [x] Sample apps updated if needed

### Solves issue(s)
<!--- Mention the GitHub issues here -->
https://github.com/opentok/opentok-react-native/issues/947

## Description

This PR introduces a series of important bug fixes for the iOS subscriber component and its React Native event handlers, specifically targeting event propagation and native crash prevention.

### Changes Included:

**1. Added Support for `onReconnected` Event on iOS**
* Implemented the missing native iOS bridging for the `onReconnected` event in `OTRNSubscriberComponentView.mm` by adding the `handleReconnected` method.
* Updated `OTSubscriberNativeComponent.ts` to include the `onReconnected` type definition.
* Connected the native `onReconnected` event to `eventHandlers.reconnected` in `OTSubscriberView.js`.

**2. Fixed Native iOS Crash due to Type Mismatch**
* Resolved a crash occurring in iOS related to error handling. Modified `prepareJSErrorEventData` in `EventUtils.swift` to explicitly cast `error.code` to a `String` before placing it into the dictionary, preventing type mismatch exceptions when bridging errors to the JS thread.

**3. Restored Missing `OTSubscriber` Event Handlers**
* Added back several missing event handlers in `OTSubscriberView.js` that are essential for tracking subscriber state and media events:
  * Renamed `subscriberConnected` back to the expected `connected`.
  * Restored handlers for `disconnected`, `videoDisabled`, `error`, `captionReceived`, `videoDisableWarning`, and `videoDisableWarningLifted`.

## How Has This Been Tested?
The changes have been verified by our QA and are working fine.
