### PR TITLE
fix: [VIDCS-4616] Fix OpentokReactNative-Swift.h import path

### DIFF
--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -37,6 +37,7 @@ Pod::Spec.new do |s|
   # Configure compiler flags and settings
   s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
   s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/boost\"",
       "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios\"",

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-// #else
-// #import <OpentokReactNative-Swift.h>
-// #endif
+#else
+#import <OpentokReactNative-Swift.h>
+#endif
 
 using namespace facebook::react;
 

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
-#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-#import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
 #import <OpentokReactNative-Swift.h>
-#endif
+// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+// #import <OpentokReactNative/OpentokReactNative-Swift.h>
+// #else
+// #endif
 
 using namespace facebook::react;
 

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -7,7 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
 #import <OpentokReactNative-Swift.h>
+#endif
 
 using namespace facebook::react;
 

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
-#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
-#import <OpentokReactNative-Swift.h>
-#endif
+// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+// #else
+// #import <OpentokReactNative-Swift.h>
+// #endif
 
 using namespace facebook::react;
 

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
 #import <OpentokReactNative-Swift.h>
-// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-// #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #else
-// #endif
+#endif
 
 using namespace facebook::react;
 

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -7,7 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
 #import <OpentokReactNative-Swift.h>
+#endif
 
 template <typename T>
 T makeConnectionStruct(NSDictionary *connectionDict) {

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
 #import <OpentokReactNative-Swift.h>
-// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-// #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #else
-// #endif
+#endif
 
 template <typename T>
 T makeConnectionStruct(NSDictionary *connectionDict) {

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-// #else
-// #import <OpentokReactNative-Swift.h>
-// #endif
+#else
+#import <OpentokReactNative-Swift.h>
+#endif
 
 template <typename T>
 T makeConnectionStruct(NSDictionary *connectionDict) {

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
-#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-#import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
 #import <OpentokReactNative-Swift.h>
-#endif
+// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+// #import <OpentokReactNative/OpentokReactNative-Swift.h>
+// #else
+// #endif
 
 template <typename T>
 T makeConnectionStruct(NSDictionary *connectionDict) {

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -7,11 +7,11 @@
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
-#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
-#import <OpentokReactNative-Swift.h>
-#endif
+// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+// #else
+// #import <OpentokReactNative-Swift.h>
+// #endif
 
 template <typename T>
 T makeConnectionStruct(NSDictionary *connectionDict) {

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-// #else
-// #import <OpentokReactNative-Swift.h>
-// #endif
+#else
+#import <OpentokReactNative-Swift.h>
+#endif
 
 typedef JS::NativeOpentok::SessionOptions RN_SessionOptions;
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
-#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
 #import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
-#import <OpentokReactNative-Swift.h>
-#endif
+// #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+// #else
+// #import <OpentokReactNative-Swift.h>
+// #endif
 
 typedef JS::NativeOpentok::SessionOptions RN_SessionOptions;
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,8 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
-#import <OpentokReactNative-Swift.h> 
-
-
+#if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
+#import <OpentokReactNative-Swift.h>
+#endif
 
 typedef JS::NativeOpentok::SessionOptions RN_SessionOptions;
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
+#import <OpentokReactNative/OpentokReactNative-Swift.h>
+#else
 #import <OpentokReactNative-Swift.h>
-// #import <OpentokReactNative/OpentokReactNative-Swift.h>
-// #else
-// #endif
+#endif
 
 typedef JS::NativeOpentok::SessionOptions RN_SessionOptions;
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <OpentokReactNative/RNOpentokReactNativeSpec.h>
 #if __has_include(<OpentokReactNative/OpentokReactNative-Swift.h>)
-#import <OpentokReactNative/OpentokReactNative-Swift.h>
-#else
 #import <OpentokReactNative-Swift.h>
-#endif
+// #import <OpentokReactNative/OpentokReactNative-Swift.h>
+// #else
+// #endif
 
 typedef JS::NativeOpentok::SessionOptions RN_SessionOptions;
 


### PR DESCRIPTION
### What is this PR doing?

Fix OpentokReactNative-Swift.h import path when the iOS lib is installed as a framework.

### What are the relevant tickets?

[VIDCS-4616](https://jira.vonage.com/browse/VIDCS-4616)

### Solves issue(s)

https://github.com/opentok/opentok-react-native/issues/930 (The error for the header file).