### PR TITLE
feat: [VIDCS-4598] Set up GitHub Actions CI pipeline for React Native SDK automated tests

### DIFF
--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -30,18 +30,13 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-          cache: yarn
+          cache: npm
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Install dependencies
-        run: yarn install --immutable
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: '3.2'
+        run: npm install
 
       - name: Install applesimutils
         run: |
@@ -56,13 +51,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pods-
 
-      - name: Install Ruby gems
+      - name: Install E2E app dependencies
         working-directory: e2e/E2ETestingApp
-        run: bundle install
+        run: npm install
 
       - name: Install CocoaPods dependencies
-        working-directory: e2e/E2ETestingApp
-        run: bundle exec pod install --project-directory=ios
+        working-directory: e2e/E2ETestingApp/ios
+        run: pod install
 
       - name: Install OpenTok SDK for credential generation
         run: npm install --no-save opentok
@@ -155,7 +150,7 @@ jobs:
           EOF
 
       - name: Build iOS Detox app
-        run: yarn test:e2e:ios:build
+        run: npm run test:e2e:ios:build
 
       - name: Run iOS Detox tests
-        run: yarn test:e2e:ios
+        run: npm run test:e2e:ios

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -79,5 +79,19 @@ jobs:
       - name: Build iOS Detox app
         run: npm run test:e2e:ios:build
 
+      - name: Start Metro bundler
+        run: |
+          nohup npm start > metro.log 2>&1 &
+          for i in {1..60}; do
+            if curl -fsS "http://127.0.0.1:8081/status" | grep -q "packager-status:running"; then
+              echo "Metro is running"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Metro failed to start"
+          tail -n 200 metro.log || true
+          exit 1
+
       - name: Run iOS Detox tests
         run: npm run test:e2e:ios

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -1,0 +1,96 @@
+name: PR CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-tests-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e-ios-tests:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Select Xcode
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install applesimutils
+        run: |
+          brew tap wix/brew
+          brew install applesimutils
+
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: e2e/E2ETestingApp/ios/Pods
+          key: ${{ runner.os }}-pods-${{ hashFiles('e2e/E2ETestingApp/ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
+
+      - name: Install Ruby gems
+        working-directory: e2e/E2ETestingApp
+        run: bundle install
+
+      - name: Install CocoaPods dependencies
+        working-directory: e2e/E2ETestingApp
+        run: bundle exec pod install --project-directory=ios
+
+      - name: Inject E2E credentials
+        env:
+          TESTING_APPLICATION_ID: ${{ secrets.TESTING_APPLICATION_ID }}
+          TESTING_SESSION_ID: ${{ secrets.TESTING_SESSION_ID }}
+          TESTING_TOKEN: ${{ secrets.TESTING_TOKEN }}
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+
+          const filePath = 'e2e/E2ETestingApp/App.tsx';
+          const applicationId = process.env.TESTING_APPLICATION_ID;
+          const sessionId = process.env.TESTING_SESSION_ID;
+          const token = process.env.TESTING_TOKEN;
+
+          if (!applicationId || !sessionId || !token) {
+            throw new Error('Missing one or more required GitHub secrets: TESTING_APPLICATION_ID, TESTING_SESSION_ID, TESTING_TOKEN.');
+          }
+
+          let source = fs.readFileSync(filePath, 'utf8');
+          source = source.replace(/applicationId:\s*'[^']*'/, `applicationId: ${JSON.stringify(applicationId)}`);
+          source = source.replace(/sessionId:\s*'[^']*'/, `sessionId: ${JSON.stringify(sessionId)}`);
+          source = source.replace(/token:\s*'[^']*'/, `token: ${JSON.stringify(token)}`);
+          fs.writeFileSync(filePath, source);
+          EOF
+
+      - name: Build iOS Detox app
+        run: yarn test:e2e:ios:build
+
+      - name: Run iOS Detox tests
+        run: yarn test:e2e:ios

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   e2e-ios-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository
+    environment: prod
     runs-on: macos-latest
     timeout-minutes: 60
 

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -80,17 +80,29 @@ jobs:
         run: npm run test:e2e:ios:build
 
       - name: Start Metro bundler
+        working-directory: e2e/E2ETestingApp
         run: |
           nohup npm start > metro.log 2>&1 &
-          for i in {1..60}; do
-            if curl -fsS "http://127.0.0.1:8081/status" | grep -q "packager-status:running"; then
-              echo "Metro is running"
+          METRO_PID=$!
+          echo "Metro PID: $METRO_PID"
+          
+          for i in {1..120}; do
+            if curl -fsS "http://127.0.0.1:8081/status" 2>/dev/null | grep -q "packager-status:running"; then
+              echo "Metro is running on attempt $i"
               exit 0
             fi
-            sleep 2
+            if ! ps -p $METRO_PID > /dev/null 2>&1; then
+              echo "Metro process died"
+              tail -n 100 metro.log || true
+              exit 1
+            fi
+            sleep 3
           done
-          echo "Metro failed to start"
-          tail -n 200 metro.log || true
+          
+          echo "Metro failed to start after 120 retries"
+          echo "=== Metro log output ==="
+          tail -n 150 metro.log || true
+          kill $METRO_PID 2>/dev/null || true
           exit 1
 
       - name: Run iOS Detox tests

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -2,7 +2,6 @@ name: PR CI
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -14,6 +13,7 @@ concurrency:
 jobs:
   e2e-ios-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository
+    environment: ${{ vars.TESTING_ENVIRONMENT }}
     runs-on: macos-latest
     timeout-minutes: 60
 
@@ -64,22 +64,87 @@ jobs:
         working-directory: e2e/E2ETestingApp
         run: bundle exec pod install --project-directory=ios
 
+      - name: Install OpenTok SDK for credential generation
+        run: npm install --no-save opentok
+
+      - name: Generate E2E session credentials
+        env:
+          API_URL: ${{ secrets.API_URL }}
+          VONAGE_API_KEY: ${{ secrets.VONAGE_API_KEY }}
+          VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const OpenTok = require('opentok');
+
+          const apiUrl = process.env.API_URL;
+          const apiKey = process.env.VONAGE_API_KEY;
+          const apiSecret = process.env.VONAGE_API_SECRET;
+          const githubEnvPath = process.env.GITHUB_ENV;
+
+          if (!apiKey || !apiSecret || !apiUrl) {
+            throw new Error('Missing one or more required GitHub secrets: VONAGE_API_KEY, VONAGE_API_SECRET, API_URL.');
+          }
+
+          if (!githubEnvPath) {
+            throw new Error('GITHUB_ENV is not available.');
+          }
+
+          const opentok = new OpenTok(apiKey, apiSecret, apiUrl);
+
+          const createSession = (options) =>
+            new Promise((resolve, reject) => {
+              opentok.createSession(options, (error, session) => {
+                if (error) {
+                  reject(error);
+                  return;
+                }
+
+                resolve(session);
+              });
+            });
+
+          (async () => {
+            const session = await createSession({ mediaMode: 'routed' });
+            const token = opentok.generateToken(session.sessionId, {
+              role: 'publisher',
+              expireTime: Math.floor(Date.now() / 1000) + 120 * 60,
+              data: `environmentUrl=${apiUrl}`,
+            });
+
+            fs.appendFileSync(
+              githubEnvPath,
+              [
+                `TESTING_API_URL=${apiUrl}`,
+                `TESTING_APPLICATION_ID=${apiKey}`,
+                `TESTING_SESSION_ID=${session.sessionId}`,
+                `TESTING_TOKEN=${token}`,
+              ].join('\n') + '\n'
+            );
+          })().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          EOF
+
       - name: Inject E2E credentials
         env:
-          TESTING_APPLICATION_ID: ${{ secrets.TESTING_APPLICATION_ID }}
-          TESTING_SESSION_ID: ${{ secrets.TESTING_SESSION_ID }}
-          TESTING_TOKEN: ${{ secrets.TESTING_TOKEN }}
+          TESTING_API_URL: ${{ env.TESTING_API_URL }}
+          TESTING_APPLICATION_ID: ${{ env.TESTING_APPLICATION_ID }}
+          TESTING_SESSION_ID: ${{ env.TESTING_SESSION_ID }}
+          TESTING_TOKEN: ${{ env.TESTING_TOKEN }}
         run: |
           node <<'EOF'
           const fs = require('fs');
 
+          const testingApiUrl = process.env.TESTING_API_URL;
           const filePath = 'e2e/E2ETestingApp/App.tsx';
           const applicationId = process.env.TESTING_APPLICATION_ID;
           const sessionId = process.env.TESTING_SESSION_ID;
           const token = process.env.TESTING_TOKEN;
 
-          if (!applicationId || !sessionId || !token) {
-            throw new Error('Missing one or more required GitHub secrets: TESTING_APPLICATION_ID, TESTING_SESSION_ID, TESTING_TOKEN.');
+          if (!testingApiUrl || !applicationId || !sessionId || !token) {
+            throw new Error('Missing one or more generated E2E values: TESTING_API_URL, TESTING_APPLICATION_ID, TESTING_SESSION_ID, TESTING_TOKEN.');
           }
 
           let source = fs.readFileSync(filePath, 'utf8');

--- a/.github/workflows/ci-pr-tests.yml
+++ b/.github/workflows/ci-pr-tests.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   e2e-ios-tests:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    environment: ${{ vars.TESTING_ENVIRONMENT }}
     runs-on: macos-latest
     timeout-minutes: 60
 
@@ -67,87 +66,14 @@ jobs:
           API_URL: ${{ secrets.API_URL }}
           VONAGE_API_KEY: ${{ secrets.VONAGE_API_KEY }}
           VONAGE_API_SECRET: ${{ secrets.VONAGE_API_SECRET }}
-        run: |
-          node <<'EOF'
-          const fs = require('fs');
-          const OpenTok = require('opentok');
-
-          const apiUrl = process.env.API_URL;
-          const apiKey = process.env.VONAGE_API_KEY;
-          const apiSecret = process.env.VONAGE_API_SECRET;
-          const githubEnvPath = process.env.GITHUB_ENV;
-
-          if (!apiKey || !apiSecret || !apiUrl) {
-            throw new Error('Missing one or more required GitHub secrets: VONAGE_API_KEY, VONAGE_API_SECRET, API_URL.');
-          }
-
-          if (!githubEnvPath) {
-            throw new Error('GITHUB_ENV is not available.');
-          }
-
-          const opentok = new OpenTok(apiKey, apiSecret, apiUrl);
-
-          const createSession = (options) =>
-            new Promise((resolve, reject) => {
-              opentok.createSession(options, (error, session) => {
-                if (error) {
-                  reject(error);
-                  return;
-                }
-
-                resolve(session);
-              });
-            });
-
-          (async () => {
-            const session = await createSession({ mediaMode: 'routed' });
-            const token = opentok.generateToken(session.sessionId, {
-              role: 'publisher',
-              expireTime: Math.floor(Date.now() / 1000) + 120 * 60,
-              data: `environmentUrl=${apiUrl}`,
-            });
-
-            fs.appendFileSync(
-              githubEnvPath,
-              [
-                `TESTING_API_URL=${apiUrl}`,
-                `TESTING_APPLICATION_ID=${apiKey}`,
-                `TESTING_SESSION_ID=${session.sessionId}`,
-                `TESTING_TOKEN=${token}`,
-              ].join('\n') + '\n'
-            );
-          })().catch((error) => {
-            console.error(error);
-            process.exit(1);
-          });
-          EOF
+        run: node scripts/generate-e2e-credentials.js
 
       - name: Inject E2E credentials
         env:
-          TESTING_API_URL: ${{ env.TESTING_API_URL }}
           TESTING_APPLICATION_ID: ${{ env.TESTING_APPLICATION_ID }}
           TESTING_SESSION_ID: ${{ env.TESTING_SESSION_ID }}
           TESTING_TOKEN: ${{ env.TESTING_TOKEN }}
-        run: |
-          node <<'EOF'
-          const fs = require('fs');
-
-          const testingApiUrl = process.env.TESTING_API_URL;
-          const filePath = 'e2e/E2ETestingApp/App.tsx';
-          const applicationId = process.env.TESTING_APPLICATION_ID;
-          const sessionId = process.env.TESTING_SESSION_ID;
-          const token = process.env.TESTING_TOKEN;
-
-          if (!testingApiUrl || !applicationId || !sessionId || !token) {
-            throw new Error('Missing one or more generated E2E values: TESTING_API_URL, TESTING_APPLICATION_ID, TESTING_SESSION_ID, TESTING_TOKEN.');
-          }
-
-          let source = fs.readFileSync(filePath, 'utf8');
-          source = source.replace(/applicationId:\s*'[^']*'/, `applicationId: ${JSON.stringify(applicationId)}`);
-          source = source.replace(/sessionId:\s*'[^']*'/, `sessionId: ${JSON.stringify(sessionId)}`);
-          source = source.replace(/token:\s*'[^']*'/, `token: ${JSON.stringify(token)}`);
-          fs.writeFileSync(filePath, source);
-          EOF
+        run: node scripts/inject-e2e-credentials.js
 
       - name: Build iOS Detox app
         run: npm run test:e2e:ios:build

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -17,7 +17,6 @@ Pod::Spec.new do |s|
   # Generate codegen files during pod install if not already generated
   s.prepare_command = <<-CMD
     cd ../../..
-    if [ ! -d "node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec" ]; then
       if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
         echo "[Codegen] Generating specs for OpentokReactNative..."
         node node_modules/react-native/scripts/generate-codegen-artifacts.js \
@@ -26,7 +25,6 @@ Pod::Spec.new do |s|
           -o node_modules/@vonage/client-sdk-video-react-native/ios \
           -s library
       fi
-    fi
   CMD
 
   s.source_files = [

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -29,9 +29,22 @@ Pod::Spec.new do |s|
     fi
   CMD
 
-  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "ios/build/generated/ios/**/*.{h,mm,cpp}"
-  s.private_header_files = "ios/build/generated/ios/**/*.h"
-  s.public_header_files = "ios/**/*.h"
+  s.source_files = [
+    "ios/*.{h,m,mm,swift}",
+    "ios/Utils/**/*.{h,m,mm,swift}",
+    "ios/generated/**/*.{h,mm,cpp,swift}"
+  ]
+  s.private_header_files = [
+    "ios/build/generated/ios/**/*.h"
+    "ios/generated/**/*.h",
+    "ios/OpentokReactNative-Bridging-Header.h"
+  ]
+  s.public_header_files = [
+    "ios/OpentokReactNative.h",
+    "ios/OTRNPublisherComponentView.h",
+    "ios/OTRNSubscriberComponentView.h",
+    "ios/OTScreenCapture.h"
+  ]
   
   # Add VonageClientSDKVideo dependency
   s.dependency 'VonageClientSDKVideo', '2.33.0'

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
   s.private_header_files = [
-    "ios/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h",
+    "ios/build/generated/ios/**/*.h"
     "ios/generated/**/*.h",
     "ios/OpentokReactNative-Bridging-Header.h"
   ]

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/opentok/opentok-react-native.git", :tag => "#{s.version}" }
 
-  # Generated codegen files are owned by ReactCodegen pod (via "Generate Specs" Xcode build phase).
-  # Exclude ios/build/** to avoid duplicate symbol conflicts with ReactCodegen.
+  # Exclude the build directory -- generated codegen files are compiled by the ReactCodegen pod,
+  # not by this pod. Headers are resolved at build time via HEADER_SEARCH_PATHS.
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.exclude_files = "ios/build/**/*"
   s.public_header_files = "ios/**/*.h"
@@ -29,9 +29,9 @@ Pod::Spec.new do |s|
     'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/boost\"",
-      # Points to the app's RN codegen output dir, populated by ReactCodegen's "Generate Specs"
-      # build phase (before_compile). Using the real directory (not Pods/Headers/Public symlinks)
-      # ensures #pragma once correctly deduplicates headers across both search paths.
+      # Points to the app's codegen output dir (populated by ReactCodegen's "Generate Specs"
+      # build phase, which runs before_compile). Resolves <RNOpentokReactNativeSpec/...> and
+      # <react/renderer/components/RNOpentokReactNativeSpec/...> imports at compile time.
       "\"${PODS_ROOT}/../build/generated/ios\""
     ].join(" "),
     "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1",
@@ -49,22 +49,5 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
-    
-    s.script_phases = [
-      {
-        :name => 'Generate Specs',
-        :script => '
-cd "${PODS_ROOT}/../.."
-node "${PODS_ROOT}/../node_modules/react-native/scripts/generate-codegen-artifacts.js" \\
-  -p "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native" \\
-  -t ios \\
-  -o "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios" \\
-  -s library
-        ',
-        :execution_position => :before_compile,
-        :input_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/package.json"],
-        :output_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios/build/generated/ios/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h"]
-      }
-    ]
   end
 end

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
   s.private_header_files = [
-    "ios/build/generated/ios/**/*.h"
+    "ios/build/generated/ios/**/*.h",
     "ios/generated/**/*.h",
     "ios/OpentokReactNative-Bridging-Header.h"
   ]

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -55,8 +55,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/boost\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/generated\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/generated/RNOpentokReactNativeSpec\""
+      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/RNOpentokReactNativeSpec\"",
+      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/react/renderer/components/RNOpentokReactNativeSpec\""
     ].join(" "),
     "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -14,38 +14,22 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/opentok/opentok-react-native.git", :tag => "#{s.version}" }
 
-  # Generate codegen files during pod install if not already generated
+  # Generate codegen files during pod install
   s.prepare_command = <<-CMD
     cd ../../..
-    if [ ! -d "node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec" ]; then
-      if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
-        echo "[Codegen] Generating specs for OpentokReactNative..."
-        node node_modules/react-native/scripts/generate-codegen-artifacts.js \
-          -p node_modules/@vonage/client-sdk-video-react-native \
-          -t ios \
-          -o node_modules/@vonage/client-sdk-video-react-native/ios \
-          -s library
-      fi
+    if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
+      echo "[Codegen] Generating specs for OpentokReactNative..."
+      node node_modules/react-native/scripts/generate-codegen-artifacts.js \
+        -p node_modules/@vonage/client-sdk-video-react-native \
+        -t ios \
+        -o node_modules/@vonage/client-sdk-video-react-native/ios \
+        -s library
     fi
   CMD
 
-  s.source_files = [
-    "ios/*.{h,m,mm,swift}",
-    "ios/Utils/**/*.{h,m,mm,swift}",
-    "ios/build/generated/ios/**/*.{h,mm,cpp,swift}",
-    "ios/generated/**/*.{h,mm,cpp,swift}"
-  ]
-  s.private_header_files = [
-    "ios/build/generated/ios/**/*.h",
-    "ios/generated/**/*.h",
-    "ios/OpentokReactNative-Bridging-Header.h"
-  ]
-  s.public_header_files = [
-    "ios/OpentokReactNative.h",
-    "ios/OTRNPublisherComponentView.h",
-    "ios/OTRNSubscriberComponentView.h",
-    "ios/OTScreenCapture.h"
-  ]
+  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "ios/build/generated/ios/**/*.{h,mm,cpp}"
+  s.private_header_files = "ios/build/generated/ios/**/*.h"
+  s.public_header_files = "ios/**/*.h" 
   
   # Add VonageClientSDKVideo dependency
   s.dependency 'VonageClientSDKVideo', '2.33.0'
@@ -53,8 +37,10 @@ Pod::Spec.new do |s|
   # Configure compiler flags and settings
   s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
   s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/boost\"",
+      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios\"",
       "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/RNOpentokReactNativeSpec\"",
       "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/react/renderer/components/RNOpentokReactNativeSpec\""
     ].join(" "),
@@ -73,5 +59,22 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+    
+    s.script_phases = [
+      {
+        :name => 'Generate Specs',
+        :script => '
+cd "${PODS_ROOT}/../.."
+node "${PODS_ROOT}/../node_modules/react-native/scripts/generate-codegen-artifacts.js" \\
+  -p "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native" \\
+  -t ios \\
+  -o "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios" \\
+  -s library
+        ',
+        :execution_position => :before_compile,
+        :input_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/package.json"],
+        :output_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios/build/generated/ios/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h"]
+      }
+    ]
   end
 end

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -14,22 +14,36 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/opentok/opentok-react-native.git", :tag => "#{s.version}" }
 
-  # Generate codegen files during pod install
+  # Generate codegen files during pod install if not already generated
   s.prepare_command = <<-CMD
     cd ../../..
-    if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
-      echo "[Codegen] Generating specs for OpentokReactNative..."
-      node node_modules/react-native/scripts/generate-codegen-artifacts.js \
-        -p node_modules/@vonage/client-sdk-video-react-native \
-        -t ios \
-        -o node_modules/@vonage/client-sdk-video-react-native/ios \
-        -s library
+    if [ ! -d "node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec" ]; then
+      if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
+        echo "[Codegen] Generating specs for OpentokReactNative..."
+        node node_modules/react-native/scripts/generate-codegen-artifacts.js \
+          -p node_modules/@vonage/client-sdk-video-react-native \
+          -t ios \
+          -o node_modules/@vonage/client-sdk-video-react-native/ios \
+          -s library
+      fi
     fi
   CMD
 
-  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "ios/build/generated/ios/**/*.{h,mm,cpp}"
-  s.private_header_files = "ios/build/generated/ios/**/*.h"
-  s.public_header_files = "ios/**/*.h" 
+  s.source_files = [
+    "ios/*.{h,m,mm,swift}",
+    "ios/Utils/**/*.{h,m,mm,swift}",
+    "ios/generated/**/*.{h,mm,cpp,swift}"
+  ]
+  s.private_header_files = [
+    "ios/generated/**/*.h",
+    "ios/OpentokReactNative-Bridging-Header.h"
+  ]
+  s.public_header_files = [
+    "ios/OpentokReactNative.h",
+    "ios/OTRNPublisherComponentView.h",
+    "ios/OTRNSubscriberComponentView.h",
+    "ios/OTScreenCapture.h"
+  ]
   
   # Add VonageClientSDKVideo dependency
   s.dependency 'VonageClientSDKVideo', '2.33.0'
@@ -39,9 +53,8 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     "HEADER_SEARCH_PATHS" => [
       "\"$(PODS_ROOT)/boost\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/RNOpentokReactNativeSpec\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/react/renderer/components/RNOpentokReactNativeSpec\""
+      "\"$(PODS_TARGET_SRCROOT)/ios/generated\"",
+      "\"$(PODS_TARGET_SRCROOT)/ios/generated/RNOpentokReactNativeSpec\""
     ].join(" "),
     "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
@@ -58,22 +71,5 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
-    
-    s.script_phases = [
-      {
-        :name => 'Generate Specs',
-        :script => '
-cd "${PODS_ROOT}/../.."
-node "${PODS_ROOT}/../node_modules/react-native/scripts/generate-codegen-artifacts.js" \\
-  -p "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native" \\
-  -t ios \\
-  -o "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios" \\
-  -s library
-        ',
-        :execution_position => :before_compile,
-        :input_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/package.json"],
-        :output_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios/build/generated/ios/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h"]
-      }
-    ]
   end
 end

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
   s.private_header_files = [
-    "ios/RNOpentokReactNativeSpec/*.h",
+    "ios/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h",
     "ios/generated/**/*.h",
     "ios/OpentokReactNative-Bridging-Header.h"
   ]

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   # Generate codegen files during pod install if not already generated
   s.prepare_command = <<-CMD
     cd ../../..
+    if [ ! -d "node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec" ]; then
       if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
         echo "[Codegen] Generating specs for OpentokReactNative..."
         node node_modules/react-native/scripts/generate-codegen-artifacts.js \
@@ -25,6 +26,7 @@ Pod::Spec.new do |s|
           -o node_modules/@vonage/client-sdk-video-react-native/ios \
           -s library
       fi
+    fi
   CMD
 
   s.source_files = [

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -35,6 +35,7 @@ Pod::Spec.new do |s|
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
   s.private_header_files = [
+    "ios/RNOpentokReactNativeSpec/*.h",
     "ios/generated/**/*.h",
     "ios/OpentokReactNative-Bridging-Header.h"
   ]

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -34,7 +34,11 @@ Pod::Spec.new do |s|
     "ios/Utils/**/*.{h,m,mm,swift}",
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
-  s.private_header_files = "ios/build/generated/ios/**/*.h"
+  s.private_header_files = [
+    "ios/build/generated/ios/**/*.h",
+    "ios/generated/**/*.h",
+    "ios/OpentokReactNative-Bridging-Header.h"
+  ]
   s.public_header_files = [
     "ios/OpentokReactNative.h",
     "ios/OTRNPublisherComponentView.h",

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -32,6 +32,7 @@ Pod::Spec.new do |s|
   s.source_files = [
     "ios/*.{h,m,mm,swift}",
     "ios/Utils/**/*.{h,m,mm,swift}",
+    "ios/build/generated/ios/**/*.{h,mm,cpp,swift}",
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
   s.private_header_files = [

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -14,8 +14,8 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/opentok/opentok-react-native.git", :tag => "#{s.version}" }
 
-  # Generated codegen files are owned by the ReactCodegen pod (added via install_modules_dependencies).
-  # Do not include ios/build/** here to avoid duplicate symbol definitions.
+  # Generated codegen files are owned by ReactCodegen pod (via "Generate Specs" Xcode build phase).
+  # Exclude ios/build/** to avoid duplicate symbol conflicts with ReactCodegen.
   s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
   s.exclude_files = "ios/build/**/*"
   s.public_header_files = "ios/**/*.h"
@@ -28,7 +28,11 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => [
-      "\"$(PODS_ROOT)/boost\""
+      "\"$(PODS_ROOT)/boost\"",
+      # Points to the app's RN codegen output dir, populated by ReactCodegen's "Generate Specs"
+      # build phase (before_compile). Using the real directory (not Pods/Headers/Public symlinks)
+      # ensures #pragma once correctly deduplicates headers across both search paths.
+      "\"${PODS_ROOT}/../build/generated/ios\""
     ].join(" "),
     "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -34,11 +34,7 @@ Pod::Spec.new do |s|
     "ios/Utils/**/*.{h,m,mm,swift}",
     "ios/generated/**/*.{h,mm,cpp,swift}"
   ]
-  s.private_header_files = [
-    "ios/build/generated/ios/**/*.h",
-    "ios/generated/**/*.h",
-    "ios/OpentokReactNative-Bridging-Header.h"
-  ]
+  s.private_header_files = "ios/build/generated/ios/**/*.h"
   s.public_header_files = [
     "ios/OpentokReactNative.h",
     "ios/OTRNPublisherComponentView.h",

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -29,22 +29,9 @@ Pod::Spec.new do |s|
     fi
   CMD
 
-  s.source_files = [
-    "ios/*.{h,m,mm,swift}",
-    "ios/Utils/**/*.{h,m,mm,swift}",
-    "ios/generated/**/*.{h,mm,cpp,swift}"
-  ]
-  s.private_header_files = [
-    "ios/build/generated/ios/**/*.h"
-    "ios/generated/**/*.h",
-    "ios/OpentokReactNative-Bridging-Header.h"
-  ]
-  s.public_header_files = [
-    "ios/OpentokReactNative.h",
-    "ios/OTRNPublisherComponentView.h",
-    "ios/OTRNSubscriberComponentView.h",
-    "ios/OTScreenCapture.h"
-  ]
+  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "ios/build/generated/ios/**/*.{h,mm,cpp}"
+  s.private_header_files = "ios/build/generated/ios/**/*.h"
+  s.public_header_files = "ios/**/*.h"
   
   # Add VonageClientSDKVideo dependency
   s.dependency 'VonageClientSDKVideo', '2.33.0'

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -71,5 +71,21 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
+    s.script_phases = [
+      {
+        :name => 'Generate Specs',
+        :script => '
+cd "${PODS_ROOT}/../.."
+node "${PODS_ROOT}/../node_modules/react-native/scripts/generate-codegen-artifacts.js" \\
+  -p "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native" \\
+  -t ios \\
+  -o "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios" \\
+  -s library
+        ',
+        :execution_position => :before_compile,
+        :input_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/package.json"],
+        :output_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h"]
+      }
+    ]
   end
 end

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -71,21 +71,5 @@ Pod::Spec.new do |s|
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"
-    s.script_phases = [
-      {
-        :name => 'Generate Specs',
-        :script => '
-cd "${PODS_ROOT}/../.."
-node "${PODS_ROOT}/../node_modules/react-native/scripts/generate-codegen-artifacts.js" \\
-  -p "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native" \\
-  -t ios \\
-  -o "${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios" \\
-  -s library
-        ',
-        :execution_position => :before_compile,
-        :input_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/package.json"],
-        :output_files => ["${PODS_ROOT}/../node_modules/@vonage/client-sdk-video-react-native/ios/generated/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h"]
-      }
-    ]
   end
 end

--- a/OpentokReactNative.podspec
+++ b/OpentokReactNative.podspec
@@ -14,23 +14,12 @@ Pod::Spec.new do |s|
   s.platforms    = { :ios => min_ios_version_supported }
   s.source       = { :git => "https://github.com/opentok/opentok-react-native.git", :tag => "#{s.version}" }
 
-  # Generate codegen files during pod install
-  s.prepare_command = <<-CMD
-    cd ../../..
-    if [ -f "node_modules/react-native/scripts/generate-codegen-artifacts.js" ]; then
-      echo "[Codegen] Generating specs for OpentokReactNative..."
-      node node_modules/react-native/scripts/generate-codegen-artifacts.js \
-        -p node_modules/@vonage/client-sdk-video-react-native \
-        -t ios \
-        -o node_modules/@vonage/client-sdk-video-react-native/ios \
-        -s library
-    fi
-  CMD
+  # Generated codegen files are owned by the ReactCodegen pod (added via install_modules_dependencies).
+  # Do not include ios/build/** here to avoid duplicate symbol definitions.
+  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}"
+  s.exclude_files = "ios/build/**/*"
+  s.public_header_files = "ios/**/*.h"
 
-  s.source_files = "ios/**/*.{h,m,mm,cpp,swift}", "ios/build/generated/ios/**/*.{h,mm,cpp}"
-  s.private_header_files = "ios/build/generated/ios/**/*.h"
-  s.public_header_files = "ios/**/*.h" 
-  
   # Add VonageClientSDKVideo dependency
   s.dependency 'VonageClientSDKVideo', '2.33.0'
   
@@ -39,10 +28,7 @@ Pod::Spec.new do |s|
   s.pod_target_xcconfig = {
     'DEFINES_MODULE' => 'YES',
     "HEADER_SEARCH_PATHS" => [
-      "\"$(PODS_ROOT)/boost\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/RNOpentokReactNativeSpec\"",
-      "\"$(PODS_TARGET_SRCROOT)/ios/build/generated/ios/react/renderer/components/RNOpentokReactNativeSpec\""
+      "\"$(PODS_ROOT)/boost\""
     ].join(" "),
     "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -DFOLLY_CFG_NO_COROUTINES=1",
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"

--- a/e2e/E2ETestingApp/ios/Podfile.lock
+++ b/e2e/E2ETestingApp/ios/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - hermes-engine (0.81.1):
     - hermes-engine/Pre-built (= 0.81.1)
   - hermes-engine/Pre-built (0.81.1)
-  - OpentokReactNative (2.32.1):
+  - OpentokReactNative (2.33.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -35,7 +35,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - SocketRocket
-    - VonageClientSDKVideo (= 2.32.1)
+    - VonageClientSDKVideo (= 2.33.0)
     - Yoga
   - RCT-Folly (2024.11.18.00):
     - boost
@@ -2370,7 +2370,7 @@ PODS:
     - React-utils (= 0.81.1)
     - SocketRocket
   - SocketRocket (0.7.1)
-  - VonageClientSDKVideo (2.32.1)
+  - VonageClientSDKVideo (2.33.0)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -2612,7 +2612,7 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  OpentokReactNative: 109cd6c63b67cb63dce040ff35529167e43bf989
+  OpentokReactNative: e137cb649b095805b6757679d015f6e949922a88
   RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
@@ -2678,7 +2678,7 @@ SPEC CHECKSUMS:
   ReactCodegen: f23844a41afe7e7264091848ce9d0eb58ff61614
   ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  VonageClientSDKVideo: b456e49a9842884b60c8f1673efeee37a749127c
+  VonageClientSDKVideo: c896347f2e45585d8347a902aa50f5662c7892cd
   Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
 
 PODFILE CHECKSUM: ec5ca63d97a4445c665d5824e0fc47fc756e7c00

--- a/e2e/E2ETestingApp/ios/Podfile.lock
+++ b/e2e/E2ETestingApp/ios/Podfile.lock
@@ -2612,75 +2612,75 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 4f8246b1f6d79f625e0d99472d1f3a71da4d28ca
-  OpentokReactNative: e137cb649b095805b6757679d015f6e949922a88
-  RCT-Folly: 846fda9475e61ec7bcbf8a3fe81edfcaeb090669
+  OpentokReactNative: 6d79fa4b03c232f742eab8eab27e426e610091eb
+  RCT-Folly: 59ec0ac1f2f39672a0c6e6cecdd39383b764646f
   RCTDeprecation: c4b9e2fd0ab200e3af72b013ed6113187c607077
   RCTRequired: e97dd5dafc1db8094e63bc5031e0371f092ae92a
   RCTTypeSafety: 720403058b7c1380c6a3ae5706981d6362962c89
   React: f1486d005993b0af01943af1850d3d4f3b597545
   React-callinvoker: 133f69368c8559e744efa345223625d412f5dfbe
-  React-Core: 559823921b4f294c2840fa8238ca958a29ddc211
-  React-CoreModules: c41e7bbfabbc420783bb926f45837a0d5e53341e
-  React-cxxreact: 9cb9fa738274a1b36b97ede09c8a6717dec1a20b
+  React-Core: d6d8c1fd33697cec596d33b820456505ee305686
+  React-CoreModules: 81ab751a7668ba161440f9623b994e1a6a3019fe
+  React-cxxreact: 16f2a2751d0dce8b569f23c1914edc90f655b01b
   React-debug: e01581e1589f329e61c95b332bf7f4969b10564b
-  React-defaultsnativemodule: bbb39447caa6b6cf9405fa0099f828c083640faa
-  React-domnativemodule: 03744d12b6d56d098531a933730bf1d4cb79bdfb
-  React-Fabric: 530b3993a12a96e8a7cdb9f0ef48e605277b572e
-  React-FabricComponents: 271ec2a9b2c00ac66fd6d1fd24e9e964d907751d
-  React-FabricImage: d0af66e976dbab7f8b81e36dd369fc70727d2695
-  React-featureflags: 269704c8eff86e0485c9d384e286350fcda6eb70
-  React-featureflagsnativemodule: db1e5d88a912fb08a5ece33fcf64e1b732da8467
-  React-graphics: b19d03a01b0722b4dc82f47acb56dc3ed41937e7
-  React-hermes: 811606c0aca5a3f9c6fa8e4994e02ca8f677e68e
-  React-idlecallbacksnativemodule: 3a3df629cd50046c7e4354f9025aefe8f2c84601
-  React-ImageManager: 0d53866c63132791e37bb2373f93044fdef14aa3
-  React-jserrorhandler: d5700d6ab7162fd575287502a3c5d601d98e7f09
-  React-jsi: ece95417fedbed0e7153a855cb8342b7c72ab75e
-  React-jsiexecutor: 2b0bb644b533df2f5c0cd6ade9a4560d0bf1dd84
-  React-jsinspector: 0c160f8510a8852bdf2dac12f0b1949efc18200b
-  React-jsinspectorcdp: f4b84409f453f61ddd8614ad45139bc594ec6bb5
-  React-jsinspectornetwork: 8f2f0ca8c871ca19b571f426002c0012e7fb2aee
-  React-jsinspectortracing: 33f6b977eb8a4bc1e3d1a4b948809aca083143f9
-  React-jsitooling: 2c61529b589e17229a9f0a4a4fc35aa7ad495850
-  React-jsitracing: 838a7b0c013c4aff7d382d7fdc78cf442013ba1d
-  React-logger: 7aef4d74123e5e3d267e5af1fbf5135b5a0d8381
-  React-Mapbuffer: 91e0eab42a6ae7f3e34091a126d70fc53bd3823e
-  React-microtasksnativemodule: 1ead4fe154df3b1ba34b5a9e35ef3c4bdfa72ccb
-  react-native-safe-area-context: befb5404eb8a16fdc07fa2bebab3568ecabcbb8a
-  React-NativeModulesApple: eff2eba56030eb0d107b1642b8f853bc36a833ac
+  React-defaultsnativemodule: e956b1d8fe15cc79d23061db229bf88170565f2f
+  React-domnativemodule: a18b0f7a31b9c75f12fa369baece5542d1265b36
+  React-Fabric: c0237a32c3c0dbea2d2b294c8e95605e1dfe2f57
+  React-FabricComponents: 65b03884bd5d9f24c79a631d7d26f0fa079bc4aa
+  React-FabricImage: de1ea2f2a0b32ad02e5cbb64827d1eec0439cf0d
+  React-featureflags: 02de9c35256cc624269b01d670d99e1fd706ea8d
+  React-featureflagsnativemodule: 8b84e67edbaa7b9318390c5bd3ae19790a74f356
+  React-graphics: 004b40c1b236ea3bb8de6693439bef9797922ba9
+  React-hermes: 2179a018b2f86652f6f33ef23efd9e5ac284b247
+  React-idlecallbacksnativemodule: f54ea68f984b12e42feed1e7110623b2c38df4d1
+  React-ImageManager: 9dd04b7b62bc5397f876ca5fb1b712e700ce390c
+  React-jserrorhandler: 2f90bf50fffea1d012e7f3d717c6adf748b1813d
+  React-jsi: b27208f8866e53238534f65f304903e4eff25e05
+  React-jsiexecutor: 1d3e827797f592c393860dea91aaa6d53c7715e7
+  React-jsinspector: bda319277ae779bc476b736fe3a497c6aed304cd
+  React-jsinspectorcdp: 69e1736edfd5420037680b7b4557fa748c3c8216
+  React-jsinspectornetwork: 7aa707b057c6129b4af59e0c9160436bbab25022
+  React-jsinspectortracing: b4a8a328ad2697f9638daa4b7cc054e0303fa47f
+  React-jsitooling: a6c7e2829437b28665e97a398b3374d443125e24
+  React-jsitracing: d87ae17dd0eef7844e605945da926c5433fe2b51
+  React-logger: d27dd2000f520bf891d24f6e141cde34df41f0ee
+  React-Mapbuffer: 0746ffab5ac0f49b7c9347338e3d0c1d9dd634c8
+  React-microtasksnativemodule: b0fb3f97372df39bda3e657536039f1af227cc29
+  react-native-safe-area-context: 0f4986a88ec555aff660503b483d6e4bd6980a9a
+  React-NativeModulesApple: 9ec9240159974c94886ebbe4caec18e3395f6aef
   React-oscompat: b12c633e9c00f1f99467b1e0e0b8038895dae436
-  React-perflogger: 58d12c4e5df1403030c97b9c621375c312cca454
-  React-performancetimeline: 0ee0a3236c77a4ee6d8a6189089e41e4003d292e
+  React-perflogger: ccf4fd2664b00818645e588623c7531a8b32d114
+  React-performancetimeline: a866ba759d8e06e9ba174b4421677edcae487baf
   React-RCTActionSheet: 3f741a3712653611a6bfc5abceb8260af9d0b218
-  React-RCTAnimation: 408ad69ea136e99a463dd33eadecc29e586b3d72
-  React-RCTAppDelegate: f03b46e80b8a3dbfa84b35abfe123e02f3ceef83
-  React-RCTBlob: bd42e92a00ad22eaab92ffe5c137e7a2f725887a
-  React-RCTFabric: b99ab638c73cf2d57b886eafdbfb2e4909b0eb9a
-  React-RCTFBReactNativeSpec: 7ad9aba0e0655e3f29be0a1c3fd4a888fab04dcf
-  React-RCTImage: 0f1c74f7cd20027f8c34976a211b35d4263a0add
-  React-RCTLinking: 6d7dfc3a74110df56c3a73cc7626bf4415656542
-  React-RCTNetwork: 6a25d8645a80d5b86098675ca39bf8fcf1afa08b
-  React-RCTRuntime: 38bfe9766565ae3293ca230bc51c9c020a8bc98a
-  React-RCTSettings: 651d9ae2cdd32f547ad0d225a2c13886d6ad2358
-  React-RCTText: 9bc66cd288478e23195e01f5cb45eba79986b2b4
-  React-RCTVibration: 371226f5667a00c76d792dcdb5c2e0fcbcde0c3b
+  React-RCTAnimation: 2edeebfba175cc2e937e2752209ab605d3c48f21
+  React-RCTAppDelegate: e292321e83ee966897244a032216a70930b758d6
+  React-RCTBlob: 8dfb24b6dd4a5af45e1e59e2fd925b2df1e44d08
+  React-RCTFabric: b25b02a2016f5cb15926a60c77a8d75865aa3558
+  React-RCTFBReactNativeSpec: 20338571a1ed853d01da6c68576aa6e8e107b6f6
+  React-RCTImage: c7fe8c2f2ae8bad98ab4d944d5d50a889da4b652
+  React-RCTLinking: 9ac21ce9f1af914bb01c06af3752db2ec840d0ee
+  React-RCTNetwork: 09a5de71d757dbad4b3fe3615839290200b932aa
+  React-RCTRuntime: da3f1e0ce088c20350044cdf1efcd7f8d9b9b40c
+  React-RCTSettings: fee112652ac7569ea9abe910206e1685f5f9adba
+  React-RCTText: 7ee9d0bc16b3a8149f8df6d70c48e724d0db1d89
+  React-RCTVibration: 619d613abaeb05f6fbc2b2e5e33f724f05df8eb8
   React-rendererconsistency: a05f6c37f9389c53213d1e28798e441fa6fbdbcd
-  React-renderercss: 6e4febfa014b0f53bc171a62b0f713ddbdbb9860
-  React-rendererdebug: e94bf27b9d55ef2795caa8e43aa92abc4a373b8b
-  React-RuntimeApple: 723be5159519eba1cd92449acb29436d21571b82
-  React-RuntimeCore: f58eb0f01065c9d27d91de10b2e4ab4c76d83b0e
-  React-runtimeexecutor: f615ec8742d0b5820170f7c8b4d2c7cb75d93ac9
-  React-RuntimeHermes: fddb258e03d330d1132bb19e78fe51ac2f3f41ac
-  React-runtimescheduler: e92a31460e654ced8587debeec37553315e1b6a5
-  React-timing: 97ada2c47b4c5932e7f773c7d239c52b90d6ca68
-  React-utils: f0949d247a46b4c09f03e5a3cb1167602d0b729a
-  ReactAppDependencyProvider: 3eb9096cb139eb433965693bbe541d96eb3d3ec9
-  ReactCodegen: f23844a41afe7e7264091848ce9d0eb58ff61614
-  ReactCommon: ce5d4226dfaf9d5dacbef57b4528819e39d3a120
+  React-renderercss: 3decb27a81648fcdee837c59994b51fff5be5a67
+  React-rendererdebug: 3b9a92d36932af52e1b473f2a89ea4b05dbdecdf
+  React-RuntimeApple: 4e35fb74be4b721c2e1fd6d54ec66456fa7043e9
+  React-RuntimeCore: 0fd7ac6e3e9dd20cb47e87c6b9f35832dd445d5e
+  React-runtimeexecutor: 7680156c9f3a5a49c688bc33f9ec5ea1b00527f5
+  React-RuntimeHermes: 435b7104a3c749af6251353dcb7317a8e53cbd73
+  React-runtimescheduler: 8056b916168e446ea44531883928034e62e76a81
+  React-timing: 36da85e32e53008ce73f87528818191e7f2508ba
+  React-utils: 71e53d55ce778c6e7c7c9db4b1b9d63ef8f55289
+  ReactAppDependencyProvider: 448b422f8af1dedf81374eacc90a15439a0ed7f5
+  ReactCodegen: c6ba7a4a1ef9b0a9f3585ae4c4794a56d0a447b9
+  ReactCommon: e897f9a1b4afab370cfefaaf5fb3c80371bc3937
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   VonageClientSDKVideo: c896347f2e45585d8347a902aa50f5662c7892cd
-  Yoga: 11c9686a21e2cd82a094a723649d9f4507200fb0
+  Yoga: fa23995c18b65978347b096d0836f4f5093df545
 
 PODFILE CHECKSUM: ec5ca63d97a4445c665d5824e0fc47fc756e7c00
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/Props.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
-#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/Props.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
+#import <RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
 #import <OpentokReactNative-Swift.h>

--- a/ios/OTRNPublisherComponentView.mm
+++ b/ios/OTRNPublisherComponentView.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <OpentokReactNative/ComponentDescriptors.h>
-#import <OpentokReactNative/EventEmitters.h>
-#import <OpentokReactNative/Props.h>
-#import <OpentokReactNative/RCTComponentViewHelpers.h>
-#import <OpentokReactNative/RNOpentokReactNativeSpec.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/Props.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
+#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
 #import <OpentokReactNative-Swift.h>

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/Props.h>
-#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
-#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/Props.h>
+#import <react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
+#import <RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
 #import <OpentokReactNative-Swift.h>

--- a/ios/OTRNSubscriberComponentView.mm
+++ b/ios/OTRNSubscriberComponentView.mm
@@ -1,10 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <OpentokReactNative/ComponentDescriptors.h>
-#import <OpentokReactNative/EventEmitters.h>
-#import <OpentokReactNative/Props.h>
-#import <OpentokReactNative/RCTComponentViewHelpers.h>
-#import <OpentokReactNative/RNOpentokReactNativeSpec.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/ComponentDescriptors.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/EventEmitters.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/Props.h>
+#import <ReactCodegen/react/renderer/components/RNOpentokReactNativeSpec/RCTComponentViewHelpers.h>
+#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <React/RCTConversions.h>
 #import <React/RCTViewComponentView.h>
 #import <OpentokReactNative-Swift.h>

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <OpentokReactNative/RNOpentokReactNativeSpec.h>
+#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <OpentokReactNative-Swift.h> 
 
 

--- a/ios/OpentokReactNative.mm
+++ b/ios/OpentokReactNative.mm
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import <ReactCodegen/RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
+#import <RNOpentokReactNativeSpec/RNOpentokReactNativeSpec.h>
 #import <OpentokReactNative-Swift.h> 
 
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -5,8 +5,16 @@ pre-commit:
       glob: "*.{js,ts,jsx,tsx}"
       run: npx eslint {staged_files}
     types:
-      glob: "*.{js,ts, jsx, tsx}"
-      run: npx tsc
+      glob: "*.{js,ts,jsx,tsx}"
+      run: npx tsc -p tsconfig.json
+    e2e-types:
+      glob: "e2e/E2ETestingApp/**/*.{js,jsx,ts,tsx}"
+      run: >-
+        if [ -d e2e/E2ETestingApp/node_modules ]; then
+          cd e2e/E2ETestingApp && npx tsc --noEmit;
+        else
+          echo "Skipping e2e typecheck (dependencies not installed in e2e/E2ETestingApp)";
+        fi
 commit-msg:
   parallel: true
   commands:

--- a/package.json
+++ b/package.json
@@ -231,12 +231,14 @@
     "type": "all",
     "jsSrcsDir": "src",
     "outputDir": {
-      "android": "android/build/generated/source/codegen",
-      "ios": "ios/build/generated/ios"
+      "ios": "ios/generated",
+      "android": "android/generated"
     },
     "android": {
       "javaPackageName": "com.opentokreactnative"
-    }
+    },
+    "includesGeneratedCode": true,
+    "fabricEnabled": true
   },
   "create-react-native-library": {
     "type": "turbo-module",

--- a/package.json
+++ b/package.json
@@ -231,8 +231,8 @@
     "type": "all",
     "jsSrcsDir": "src",
     "outputDir": {
-      "ios": "ios/generated",
-      "android": "android/generated"
+      "android": "android/build/generated/source/codegen",
+      "ios": "ios/build/generated/ios"
     },
     "android": {
       "javaPackageName": "com.opentokreactnative"

--- a/package.json
+++ b/package.json
@@ -236,7 +236,9 @@
     },
     "android": {
       "javaPackageName": "com.opentokreactnative"
-    }
+    },
+    "includesGeneratedCode": true,
+    "fabricEnabled": true
   },
   "create-react-native-library": {
     "type": "turbo-module",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "types": "./lib/typescript/commonjs/src/index.d.ts",
         "default": "./lib/commonjs/index.js"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "app.plugin": "./app.plugin.js",
   "expo": {

--- a/package.json
+++ b/package.json
@@ -236,9 +236,7 @@
     },
     "android": {
       "javaPackageName": "com.opentokreactnative"
-    },
-    "includesGeneratedCode": true,
-    "fabricEnabled": true
+    }
   },
   "create-react-native-library": {
     "type": "turbo-module",

--- a/scripts/generate-e2e-credentials.js
+++ b/scripts/generate-e2e-credentials.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const OpenTok = require('opentok');
+
+const apiUrl = process.env.API_URL;
+const apiKey = process.env.VONAGE_API_KEY;
+const apiSecret = process.env.VONAGE_API_SECRET;
+const githubEnvFile = process.env.GITHUB_ENV;
+
+if (!apiKey || !apiSecret || !apiUrl) {
+  throw new Error(
+    'Missing one or more required GitHub secrets: VONAGE_API_KEY, VONAGE_API_SECRET, API_URL.'
+  );
+}
+
+if (!githubEnvFile) {
+  throw new Error('GITHUB_ENV is not available.');
+}
+
+const opentok = new OpenTok(apiKey, apiSecret, apiUrl);
+
+const createSession = (options) =>
+  new Promise((resolve, reject) => {
+    opentok.createSession(options, (error, session) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+
+      resolve(session);
+    });
+  });
+
+(async () => {
+  const session = await createSession({ mediaMode: 'routed' });
+  const token = opentok.generateToken(session.sessionId, {
+    role: 'publisher',
+    expireTime: Math.floor(Date.now() / 1000) + 120 * 60,
+    data: `environmentUrl=${apiUrl}`,
+  });
+
+  fs.appendFileSync(
+    githubEnvFile,
+    [
+      `TESTING_APPLICATION_ID=${apiKey}`,
+      `TESTING_SESSION_ID=${session.sessionId}`,
+      `TESTING_TOKEN=${token}`,
+    ].join('\n') + '\n'
+  );
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/generate-e2e-credentials.js
+++ b/scripts/generate-e2e-credentials.js
@@ -8,9 +8,17 @@ const apiKey = process.env.VONAGE_API_KEY;
 const apiSecret = process.env.VONAGE_API_SECRET;
 const githubEnvFile = process.env.GITHUB_ENV;
 
-if (!apiKey || !apiSecret || !apiUrl) {
+const missingParams = [
+  ['VONAGE_API_KEY', apiKey],
+  ['VONAGE_API_SECRET', apiSecret],
+  ['API_URL', apiUrl],
+].filter(([, value]) => !value);
+
+if (missingParams.length > 0) {
   throw new Error(
-    'Missing one or more required GitHub secrets: VONAGE_API_KEY, VONAGE_API_SECRET, API_URL.'
+    `Missing required GitHub secrets: ${missingParams
+      .map(([name]) => name)
+      .join(', ')}.`
   );
 }
 

--- a/scripts/inject-e2e-credentials.js
+++ b/scripts/inject-e2e-credentials.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const filePath = path.join(__dirname, '../e2e/E2ETestingApp/App.tsx');
+const applicationId = process.env.TESTING_APPLICATION_ID;
+const sessionId = process.env.TESTING_SESSION_ID;
+const token = process.env.TESTING_TOKEN;
+
+if (!applicationId || !sessionId || !token) {
+  throw new Error(
+    'Missing one or more generated E2E values: TESTING_APPLICATION_ID, TESTING_SESSION_ID, TESTING_TOKEN.'
+  );
+}
+
+let source = fs.readFileSync(filePath, 'utf8');
+source = source.replace(
+  /applicationId:\s*'[^']*'/,
+  `applicationId: ${JSON.stringify(applicationId)}`
+);
+source = source.replace(
+  /sessionId:\s*'[^']*'/,
+  `sessionId: ${JSON.stringify(sessionId)}`
+);
+source = source.replace(/token:\s*'[^']*'/, `token: ${JSON.stringify(token)}`);
+fs.writeFileSync(filePath, source);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,7 @@
     "strict": true,
     "target": "ESNext",
     "verbatimModuleSyntax": true
-  }
+  },
+  "include": ["src/**/*", "@types/**/*"],
+  "exclude": ["lib", "e2e", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4801,7 +4801,7 @@ duplexer2@^0.1.2:
   dependencies:
     readable-stream "^2.0.2"
 
-"E2ETestingApp@file:/Users/iperunovic/Code/vonage-video-react-native-sdk/e2e/E2ETestingApp":
+"E2ETestingApp@file:/Users/joliveraortega/source/repos/vonage-video-react-native-sdk/e2e/E2ETestingApp":
   version "0.0.1"
   resolved "file:e2e/E2ETestingApp"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3237,7 +3237,7 @@
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
 "@vonage/client-sdk-video-react-native@file:../..":
-  version "2.32.1"
+  version "2.33.0"
   resolved "file:"
   dependencies:
     axios "^1.13.2"


### PR DESCRIPTION
Improvement: https://jira.vonage.com/browse/VIDCS-4598

Also, changed the commit rules so the testing app and the sdk don't have to be built for the commit to work (since those generated files aren't committed anyway)