### PR TITLE
fix: [VIDCS-4694] Get rid of dependency.platforms.ios.podspecPath warning

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -5,9 +5,7 @@ module.exports = {
   dependency: {
     platforms: {
       android: {},
-      ios: {
-        podspecPath: 'OpentokReactNative.podspec',
-      },
+      ios: {},
     },
   },
 };


### PR DESCRIPTION
### What is this PR doing?

Getting rid of "warn Package @vonage/client-sdk-video-react-native contains invalid configuration: "dependency.platforms.ios.podspecPath" warning message.

### What are the relevant tickets?

[VIDCS-4694](https://jira.vonage.com/browse/VIDCS-4694)

### Contributing checklist
- [ ] Code must follow existing styling conventions
- [ ] Added a descriptive commit message
- [ ] Sample apps updated if needed

### Solves issue(s)

https://github.com/Vonage/vonage-video-react-native-sdk/issues/82