### PR TITLE
fix: [VIDCS-4666] Subscriber defaults, context and subscriber child fixes

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -736,7 +736,7 @@ declare module "@vonage/client-sdk-video-react-native" {
     preferredResolution?: string;
 
     /**
-     * Whether to subscribe to audio.
+      * Whether to subscribe to audio. Defaults to true.
      */
     subscribeToAudio?: boolean;
 
@@ -746,7 +746,7 @@ declare module "@vonage/client-sdk-video-react-native" {
     subscribeToCaptions?: boolean;
 
     /**
-     * Whether to subscribe video.
+      * Whether to subscribe video. Defaults to true.
      */
     subscribeToVideo?: boolean;
 

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -19,7 +19,6 @@ import {
 import OTContext from './contexts/OTContext';
 
 export default class OTSubscriber extends Component {
-  // sessionInfo = this.context.sessionInfo;
 
   constructor(props, context) {
     super(props, context);
@@ -35,7 +34,6 @@ export default class OTSubscriber extends Component {
       streamProperties: props.streamProperties,
       subscribeToSelf: props.subscribeToSelf || false,
     };
-    // this.otrnEventHandler = getOtrnErrorEventHandler(this.props.eventHandlers);
     this.initComponent();
   }
 

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -19,7 +19,6 @@ import {
 import OTContext from './contexts/OTContext';
 
 export default class OTSubscriber extends Component {
-  sessionId = this.context.sessionId;
   // sessionInfo = this.context.sessionInfo;
 
   constructor(props, context) {
@@ -151,7 +150,7 @@ export default class OTSubscriber extends Component {
         return (
           <OTContext.Provider
             value={{
-              sessionId: this.sessionId,
+              sessionId: this.context.sessionId,
               subscriberProperties: this.state.properties,
               streamProperties: this.state.streamProperties,
               eventHandlers: this.props.eventHandlers,
@@ -162,7 +161,6 @@ export default class OTSubscriber extends Component {
             <OTSubscriberView
               streamId={streamId}
               style={style}
-              {...this.props.properties}
             />
           </OTContext.Provider>
         );
@@ -173,7 +171,7 @@ export default class OTSubscriber extends Component {
       return this.props.children(this.state.streams).map((elem) => (
         <OTContext.Provider
           value={{
-            sessionId: this.sessionId,
+            sessionId: this.context.sessionId,
             subscriberProperties: this.state.properties,
             streamProperties: this.state.streamProperties,
             style: this.props.style,

--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -141,46 +141,39 @@ export default class OTSubscriber extends Component {
   }
 
   render() {
+    const contextValue = {
+      sessionId: this.context.sessionId,
+      subscriberProperties: this.state.properties,
+      streamProperties: this.state.streamProperties,
+      eventHandlers: this.props.eventHandlers,
+      style: this.props.style,
+    };
+
     if (!this.props.children) {
       const containerStyle = this.props.containerStyle;
-      const childrenWithStreams = this.state.streams.map((streamId) => {
-        const style = this.state.style;
-        return (
-          <OTContext.Provider
-            value={{
-              sessionId: this.context.sessionId,
-              subscriberProperties: this.state.properties,
-              streamProperties: this.state.streamProperties,
-              eventHandlers: this.props.eventHandlers,
-              style: this.props.style,
-            }}
-            key={streamId}
-          >
-            <OTSubscriberView
-              streamId={streamId}
-              style={style}
-            />
-          </OTContext.Provider>
-        );
-      });
-      return <View style={containerStyle}>{childrenWithStreams}</View>;
-    }
-    if (this.props.children(this.state.streams)) {
-      return this.props.children(this.state.streams).map((elem) => (
-        <OTContext.Provider
-          value={{
-            sessionId: this.context.sessionId,
-            subscriberProperties: this.state.properties,
-            streamProperties: this.state.streamProperties,
-            style: this.props.style,
-            eventHandlers: this.props.eventHandlers,
-          }}
-          key={elem.props.streamId}
-        >
-          {elem}
-        </OTContext.Provider>
+      const childrenWithStreams = this.state.streams.map((streamId) => (
+        <OTSubscriberView
+          key={streamId}
+          streamId={streamId}
+          style={this.props.style}
+        />
       ));
+      return (
+        <OTContext.Provider value={contextValue}>
+          <View style={containerStyle}>{childrenWithStreams}</View>
+        </OTContext.Provider>
+      );
     }
+
+    const renderedChildren = this.props.children(this.state.streams);
+    if (renderedChildren) {
+      return (
+        <OTContext.Provider value={contextValue}>
+          {renderedChildren}
+        </OTContext.Provider>
+      );
+    }
+
     return null;
   }
 }

--- a/src/OTSubscriberNativeComponent.ts
+++ b/src/OTSubscriberNativeComponent.ts
@@ -4,6 +4,7 @@ import type {
   Double,
   Float,
   Int32,
+  WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 
@@ -68,8 +69,8 @@ export interface VideoEnabledEvent extends StreamEvent {
 export interface NativeProps extends ViewProps {
   sessionId: string;
   streamId: string;
-  subscribeToAudio?: boolean;
-  subscribeToVideo?: boolean;
+  subscribeToAudio?: WithDefault<boolean, true>;
+  subscribeToVideo?: WithDefault<boolean, true>;
   scaleBehavior?: string;
 
   subscribeToCaptions?: boolean;

--- a/src/OTSubscriberView.js
+++ b/src/OTSubscriberView.js
@@ -14,28 +14,18 @@ export default class OTSubscriberView extends React.Component {
     },
   };
 
-  sessionId = this.context.sessionId;
-
-  eventHandlers = {};
-
-  constructor(props, context) {
-    super(props, context);
-    this.eventHandlers = props.eventHandlers;
-    this.style = props.style;
-  }
-
   getRtcStatsReport() {
     //NOSONAR - this method is exposed externally
-    OT.getSubscriberRtcStatsReport(this.sessionId);
+    OT.getSubscriberRtcStatsReport(this.context.sessionId);
   }
 
   componentWillUnmount() {
-    OT.removeSubscriber(this.sessionId, this.props.streamId);
+    OT.removeSubscriber(this.context.sessionId, this.props.streamId);
   }
 
   render() {
     const { streamId } = this.props;
-    const subscriberProperties = this.context.subscriberProperties;
+    const subscriberProperties = this.context.subscriberProperties || {};
     const eventHandlers = this.context.eventHandlers;
     const streamProperties = this.context.streamProperties
       ? this.context.streamProperties[streamId]
@@ -69,7 +59,7 @@ export default class OTSubscriberView extends React.Component {
     const style = streamProperties?.style || this.context.style;
     return (
       <OTRNSubscriber
-        sessionId={this.sessionId}
+        sessionId={this.context.sessionId}
         streamId={streamId}
         subscribeToAudio={subscribeToAudio}
         subscribeToVideo={subscribeToVideo}

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,8 +210,16 @@ export type OTSubscriberProperties = {
         width?: number;
         height?: number;
       };
+
+  /**
+   * Defaults to `true` when omitted.
+   */
   subscribeToAudio?: boolean;
   subscribeToCaptions?: boolean;
+  
+  /**
+   * Defaults to `true` when omitted.
+   */
   subscribeToVideo?: boolean;
   scaleBehavior?: VideoScaleType;
   style?: StyleProp<ViewStyle>;


### PR DESCRIPTION
https://jira.vonage.com/browse/VIDCS-4666

subscriber now has defaults as intended

it also assigns the sessionId on render instead of constructor, thus avoiding concurrence issues.