### PR TITLE
fix(subscriber): parse iOS network-stats jsonStats into the typed payload (#151)

### DIFF
--- a/src/OTSubscriberView.js
+++ b/src/OTSubscriberView.js
@@ -72,7 +72,12 @@ export default class OTSubscriberView extends React.Component {
           eventHandlers.audioLevel?.(event.nativeEvent);
         }}
         onAudioNetworkStats={(event) => {
-          eventHandlers.audioNetworkStats?.(event.nativeEvent);
+          // iOS ships these stats wrapped as { stream, jsonStats: "<string>" };
+          // parse them so consumers get the structured payload the type advertises.
+          const eventData = event.nativeEvent.jsonStats
+            ? JSON.parse(event.nativeEvent.jsonStats)
+            : event.nativeEvent;
+          eventHandlers.audioNetworkStats?.(eventData);
         }}
         onSubscriberConnected={(event) => {
           eventHandlers.connected?.(event.nativeEvent);
@@ -109,7 +114,12 @@ export default class OTSubscriberView extends React.Component {
           eventHandlers.reconnected?.(event.nativeEvent);
         }}
         onVideoNetworkStats={(event) => {
-          eventHandlers.videoNetworkStats?.(event.nativeEvent);
+          // iOS ships these stats wrapped as { stream, jsonStats: "<string>" };
+          // parse them so consumers get the structured payload the type advertises.
+          const eventData = event.nativeEvent.jsonStats
+            ? JSON.parse(event.nativeEvent.jsonStats)
+            : event.nativeEvent;
+          eventHandlers.videoNetworkStats?.(eventData);
         }}
         style={style}
       />


### PR DESCRIPTION
Fixes #151

## Problem

On iOS, subscriber `videoNetworkStats`/`audioNetworkStats` handlers receive `{ stream, jsonStats: "<string>" }` instead of the structured `VideoNetworkStatsEvent`/`AudioNetworkStatsEvent` the types advertise, so every advertised field is `undefined`. Android is correct — behaviour is inconsistent across platforms. `OTSubscriberView` forwarded `event.nativeEvent` unchanged; the iOS layer wraps the stats as `jsonStats`.

## Fix

Parse `jsonStats` when present (mirrors the existing `OTPublisher` workaround). Android's already-structured payload is unaffected.

## Verification (iOS 26.5 simulator, two participants)

With a second peer publishing, the primary's subscriber network-stats handler fired:
- **before:** payload shape `WRAPPED` (has `jsonStats`, no `videoPacketsLost`);
- **after:** payload shape `STRUCTURED` (typed fields present).

Note: a CI e2e regression test would require a second publishing participant (not available in the single-device CI), so this was verified manually with a two-simulator setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
