### PR TITLE
fix: removeEventListener removes only the target listener (fixes multi-subscriber teardown + streamCreated leak)

### DIFF
--- a/src/OTSubscriber.js
+++ b/src/OTSubscriber.js
@@ -117,7 +117,11 @@ export default class OTSubscriber extends Component {
   }
 
   componentWillUnmount() {
-    removeEventListener('streamCreated', this.streamCreatedHandler);
+    removeEventListener(
+      this.context.sessionId,
+      'streamCreated',
+      this.streamCreatedHandler
+    );
     removeEventListener(
       this.context.sessionId,
       'publisherStreamCreated',

--- a/src/__tests__/OTSessionHelper.test.js
+++ b/src/__tests__/OTSessionHelper.test.js
@@ -3,6 +3,7 @@ import {
   clearStreams,
   dispatchEvent,
   getPublisherStream,
+  removeEventListener,
   sanitizeSessionOptions,
 } from '../helpers/OTSessionHelper';
 
@@ -19,6 +20,43 @@ describe('OTSessionHelper', () => {
     expect(listener).toHaveBeenCalledWith({ streamId: 'stream-1' });
     expect(getPublisherStream(sessionId)).toBe('stream-1');
 
+    clearStreams(sessionId);
+  });
+
+  it('removeEventListener removes only the given listener, leaving others of the same type intact', () => {
+    // Two components (e.g. two OTSubscribers) registered on the same session/type.
+    const sessionId = 'session-remove';
+    const first = jest.fn();
+    const second = jest.fn();
+
+    addEventListener(sessionId, 'streamDestroyed', first);
+    addEventListener(sessionId, 'streamDestroyed', second);
+
+    // First component unmounts and removes its own listener.
+    removeEventListener(sessionId, 'streamDestroyed', first);
+
+    dispatchEvent(sessionId, 'streamDestroyed', { streamId: 'stream-2' });
+
+    // The removed listener must not fire...
+    expect(first).not.toHaveBeenCalled();
+    // ...but the surviving component's listener MUST still receive the event.
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledWith({ streamId: 'stream-2' });
+
+    clearStreams(sessionId);
+  });
+
+  it('removeEventListener is a no-op for a listener that was never registered', () => {
+    const sessionId = 'session-remove-noop';
+    const only = jest.fn();
+    const other = jest.fn();
+
+    addEventListener(sessionId, 'streamDestroyed', only);
+    removeEventListener(sessionId, 'streamDestroyed', other);
+
+    dispatchEvent(sessionId, 'streamDestroyed', { streamId: 'stream-3' });
+
+    expect(only).toHaveBeenCalledTimes(1);
     clearStreams(sessionId);
   });
 

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -85,7 +85,15 @@ const addEventListener = (sessionId, type, listener) => {
 };
 
 const removeEventListener = (sessionId, type, listener) => {
-  if (eventHandlers[sessionId] && eventHandlers[sessionId][type]) {
+  const listeners = eventHandlers[sessionId] && eventHandlers[sessionId][type];
+  if (!listeners) {
+    return;
+  }
+  const index = listeners.indexOf(listener);
+  if (index !== -1) {
+    listeners.splice(index, 1);
+  }
+  if (listeners.length === 0) {
     delete eventHandlers[sessionId][type];
   }
 };


### PR DESCRIPTION
## What

Fixes two related defects in the JS event bus:

1. **`removeEventListener` deleted the whole listener array for an event type** instead of the single matching listener. `addEventListener` stores `eventHandlers[sessionId][type]` as an **array** (multiple components register for the same type on a session), but `removeEventListener` did `delete eventHandlers[sessionId][type]` and never inspected the `listener` argument. Unmounting one component (e.g. one `OTSubscriber`) therefore removed **every** other component's handlers for that event type — the survivors stopped reacting to `streamDestroyed` / `streamCreated`, leaving stale/frozen subscriber tiles.

2. **`OTSubscriber.componentWillUnmount` called `removeEventListener('streamCreated', handler)` with only two args.** The signature is `(sessionId, type, listener)`, so `sessionId` became `'streamCreated'` and the call never matched a real entry — the `streamCreated` listener was never removed and leaked on every unmount. (The other four calls in that method already pass three args.)

## Fix

- `src/helpers/OTSessionHelper.js`: locate the listener with `indexOf` and `splice` only that entry; delete the array key only once it is empty.
- `src/OTSubscriber.js`: pass `this.context.sessionId` to the `streamCreated` removal.

## Tests

Adds two regression tests to `src/__tests__/OTSessionHelper.test.js`:
- removing one listener leaves other listeners of the same type intact (the survivor still fires) — **fails on `develop`** (survivor fired 0 times), passes here;
- removing a never-registered listener is a no-op.

Full SDK test suite passes; lint and typecheck pass (pre-commit hooks green).

Fixes #158
