### PR TITLE
fix(android): correct pub/sub map-key removal + resource release on view teardown

### DIFF
--- a/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisher.kt
@@ -75,6 +75,19 @@ class OTRNPublisher : FrameLayout, PublisherListener,
         this.setLayoutParams(params)
     }
 
+    // Releases the publisher's native resources (camera capturer, encoder, renderer)
+    // and detaches its view on final teardown. Called from
+    // OTRNPublisherManager.onDropViewInstance (fires on real destruction, not recycling),
+    // so the ~0.6 MB/cycle native leak of an un-destroyed Publisher is reclaimed.
+    fun cleanUpMemory() {
+        removeAllViews()
+        (props?.get("publisherId") as? String)?.let {
+            sharedState.getPublishers().remove(it)
+        }
+        publisher?.destroy()
+        publisher = null
+    }
+
     fun emitOpenTokEvent(name: String, payload: WritableMap) {
         val reactContext = context as ReactContext
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)

--- a/android/src/main/java/com/opentokreactnative/OTRNPublisherManager.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNPublisherManager.kt
@@ -30,6 +30,11 @@ class OTRNPublisherManager(context: ReactApplicationContext) :
         return OTRNPublisher(context)
     }
 
+    override fun onDropViewInstance(view: OTRNPublisher) {
+        view.cleanUpMemory()
+        super.onDropViewInstance(view)
+    }
+
     override fun getNativeProps(): Map<String?, String?>? {
         return super.getNativeProps()
     }

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriber.kt
@@ -188,6 +188,21 @@ class OTRNSubscriber : FrameLayout, SubscriberListener,
         this.setLayoutParams(params)
     }
 
+    // Releases the subscriber's native resources (decoder, renderer) and detaches its
+    // view on final teardown. Called from OTRNSubscriberManager.onDropViewInstance
+    // (fires on real destruction, not recycling), mirroring the publisher cleanup so
+    // an un-destroyed Subscriber + its subscriberStreams/subscribers map entries are
+    // not retained for the process lifetime.
+    fun cleanUpMemory() {
+        removeAllViews()
+        streamId?.let {
+            sharedState.getSubscribers().remove(it)
+            sharedState.getSubscriberStreams().remove(it)
+        }
+        subscriber?.destroy()
+        subscriber = null
+    }
+
     fun emitOpenTokEvent(name: String, payload: WritableMap) {
         val reactContext = context as ReactContext
         val surfaceId = UIManagerHelper.getSurfaceId(reactContext)

--- a/android/src/main/java/com/opentokreactnative/OTRNSubscriberManager.kt
+++ b/android/src/main/java/com/opentokreactnative/OTRNSubscriberManager.kt
@@ -25,6 +25,11 @@ class OTRNSubscriberManager(context: ReactApplicationContext) :
     override fun createViewInstance(context: ThemedReactContext): OTRNSubscriber =
         OTRNSubscriber(context)
 
+    override fun onDropViewInstance(view: OTRNSubscriber) {
+        view.cleanUpMemory()
+        super.onDropViewInstance(view)
+    }
+
     @ReactProp(name = "streamId")
     override public fun setStreamId(view: OTRNSubscriber, streamId: String?) {
         view.setStreamId(streamId)

--- a/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
+++ b/android/src/main/java/com/opentokreactnative/OpentokReactNativeModule.java
@@ -199,7 +199,7 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
         Publisher publisher = publishers.get(publisherId);
         if (publisher != null) {
             mSession.unpublish(publisher);
-            publishers.remove(publisher);
+            publishers.remove(publisherId);
         }
     }
 
@@ -217,7 +217,7 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
                 Subscriber subscriber = subscribers.get(streamId);
                 if (subscriber != null) {
                     mSession.unsubscribe(subscriber);
-                    subscribers.remove(subscriber);
+                    subscribers.remove(streamId);
                 }
             };
         });
@@ -390,6 +390,9 @@ public class OpentokReactNativeModule extends NativeOpentokSpec implements
     @Override
     public void onStreamDropped(Session session, Stream stream) {
         WritableMap payload = EventUtils.prepareJSStreamMap(stream, session);
+        // The stream was put into subscriberStreams on onStreamReceived; remove it here
+        // so ended remote streams don't accumulate for the process lifetime.
+        sharedState.getSubscriberStreams().remove(stream.getStreamId());
         emitOnStreamDestroyed(payload);
     }
 


### PR DESCRIPTION
> ## Update — scope correction (follow-up profiling)
>
> More isolated profiling (mount/unmount the `OTPublisher` while the session stays **connected**, so only the publisher view churns) shows the **native heap still grows ~0.65–0.79 MB/cycle even with the full teardown firing** — `onDropViewInstance` → `cleanUpMemory` → `Publisher.destroy()`, plus an explicit `capturer.getCapturer().stopCapture()` (returns 0), all confirmed firing 30/30. An **audio-only** publisher (`videoTrack: false`, no camera) is **flat**. Category breakdown: the growth is Native Heap + thread stacks, no EGL/GL.
>
> So the residual native leak is the **camera/video capture+encode pipeline inside `com.vonage:client-sdk-video`** — below the RN wrapper — and is **not** closed by this PR (and is **not** primarily the JS `OTSession`-subscription leak referenced further down; that attribution was wrong).
>
> **What this PR legitimately fixes (correctness + hygiene — still worth merging):**
> - `remove(publisher)` → `remove(publisherId)`: removing by **value** on a `ConcurrentHashMap<String,_>` is a guaranteed no-op, so the maps retain `Publisher`/`Subscriber` references (a real reference/logical leak).
> - the missing `Publisher/Subscriber.destroy()` on view teardown, and the stale `subscriberStreams` entries.
>
> The measured native reduction should be read as **releasing those retained references**, not as closing the underlying native-pipeline leak (vendor-side, to be filed separately against `com.vonage:client-sdk-video`).
>
> ---

Fixes #169.

## Before / after (measured)

```mermaid
xychart-beta
    title "Android idle native heap — BEFORE (upper line, ~1.14 MB/cyc) vs AFTER map-remove fix (lower line, ~0.62 MB/cyc)"
    x-axis "connect / disconnect cycle" [1,2,3,4,5,6,7,8,9,10,11,12,13,14]
    y-axis "native heap (MB, after GC)" 78 --> 100
    line [81.1,82.3,83.5,84.7,85.6,86.7,87.9,88.6,89.9,90.7,91.8,93.1,94.7,96.2]
    line [80.1,81.2,81.5,82.3,82.9,83.6,84.1,84.6,85.1,85.8,86.4,86.8,87.3,87.9]
```

_Upper (red) = before; lower (green) = after the `remove(publisherId/streamId)` fix. Slope drops from ~1.14 → ~0.62 MB/cycle (−46%). The remaining slope is dominated by the separate JS `OTSession`-subscription leak (PR #155), not this Android teardown path._

---

## What

Fixes four native-memory-teardown gaps on Android, **found by runtime memory profiling** (`adb shell dumpsys meminfo` across repeated connect→publish→disconnect cycles on an API-36 emulator, GC-forced, Java heap held flat to isolate native). The app leaked native memory every session cycle.

| # | Leak | Fix |
|---|---|---|
| 1 | `unpublish()`/`removeSubscriber()` call `publishers.remove(publisher)` / `subscribers.remove(subscriber)` — the **value** object as the key on a `ConcurrentHashMap<String,_>` → guaranteed no-op → Publisher/Subscriber (+ native camera/encoder/renderer) retained forever | `remove(publisherId)` / `remove(streamId)` |
| 2 | `OTRNPublisher` adds `publisher.view` but never releases it or the `Publisher` on unmount (no drop hook, no `destroy()`) | `cleanUpMemory()` (`removeAllViews` + map remove + `publisher.destroy()`) from `OTRNPublisherManager.onDropViewInstance` |
| 3 | `onStreamDropped` never removed the stream from `subscriberStreams` → ended remote streams accumulate for the process lifetime | remove on drop |
| 4 | `OTRNSubscriber` had the same missing teardown as #2 | `cleanUpMemory()` (`removeAllViews` + `subscribers`/`subscriberStreams` remove + `subscriber.destroy()`) from `OTRNSubscriberManager.onDropViewInstance` |

`onDropViewInstance` is used (not `onDetachedFromWindow`) because it fires on real destruction, not view recycling — so this can't break attach/detach.

## Measurement

Before any fix, idle **native heap grew ~1.14 MB per cycle, linearly, over 26 cycles, with no plateau** (Java heap flat after GC → the leak is native). Fix #1 alone dropped it to **~0.62 MB/cycle** (measured).

## Verification & honesty

- **`assembleDebug` BUILD SUCCESSFUL**; connect→"Session Active"→disconnect still works across cycles with no crash (`destroy()`/`onDropViewInstance` are safe).
- **#1 is measured** (−46%). **#2** is a correct native-resource release (the SDK exposes `destroy()` for exactly this); its isolated per-cycle delta sits within measurement noise in this branch because the tree still carries the **separate JS `OTSession` subscription leak** (tracked in PR #155, not yet merged) which dominates the residual.
- **#3/#4 are the subscriber-side analogs** of the profiled publisher leaks — code-symmetric with #1/#2; fully confirming them at runtime needs a second peer publishing/leaving (follow-up).
- Fixes are RN-version-independent (Android teardown); built/verified on the RN 0.86 branch, applies cleanly to `develop`.

Part of a broader memory-leak census; see the other open leak PRs (#155/#159 JS, #167 iOS KVO).

