### PR TITLE
fix(js): honor maxVideoBitrate and track the first stream of a session

### DIFF
--- a/src/__tests__/OTPublisherHelper.test.js
+++ b/src/__tests__/OTPublisherHelper.test.js
@@ -17,4 +17,17 @@ describe('sanitizeProperties', () => {
 
     expect(result.preferredVideoCodecs).toBe('vp8;h264'); //it should clear duplicates and remove invalid values
   });
+
+  // Regression: maxVideoBitrate was sanitized from the wrong field
+  // (videoBitratePreset, a string) so it was always 0 and silently ignored.
+  it('applies maxVideoBitrate instead of always returning 0', () => {
+    expect(sanitizeProperties({ maxVideoBitrate: 2000000 }).maxVideoBitrate).toBe(
+      2000000
+    );
+    // clamps within the valid range and defaults to 0 when unset
+    expect(sanitizeProperties({ maxVideoBitrate: 1000 }).maxVideoBitrate).toBe(
+      5000
+    );
+    expect(sanitizeProperties({}).maxVideoBitrate).toBe(0);
+  });
 });

--- a/src/__tests__/OTSessionHelper.test.js
+++ b/src/__tests__/OTSessionHelper.test.js
@@ -1,8 +1,10 @@
 import {
   addEventListener,
+  addStream,
   clearStreams,
   dispatchEvent,
   getPublisherStream,
+  getStreams,
   sanitizeSessionOptions,
 } from '../helpers/OTSessionHelper';
 
@@ -30,5 +32,19 @@ describe('OTSessionHelper', () => {
 
     expect(result.apiUrl).toBe('');
     expect(result.connectionEventsSuppressed).toBe(true);
+  });
+
+  // Regression: addStream no-op'd on the first stream of a session because the
+  // per-session array was never initialized, so the first remote stream was lost.
+  it('tracks the first stream of a session', () => {
+    const sessionId = 'session-addstream';
+
+    addStream(sessionId, 'stream-1');
+    addStream(sessionId, 'stream-2');
+    addStream(sessionId, 'stream-1'); // dedupe
+
+    expect(getStreams(sessionId)).toEqual(['stream-1', 'stream-2']);
+
+    clearStreams(sessionId);
   });
 });

--- a/src/helpers/OTPublisherHelper.js
+++ b/src/helpers/OTPublisherHelper.js
@@ -198,7 +198,7 @@ const sanitizeProperties = (properties) => {
       properties.allowAudioCaptureWhileMuted
     ),
     publishSenderStats: Boolean(properties.publishSenderStats),
-    maxVideoBitrate: sanitizeMaxVideoBitrate(properties.videoBitratePreset),
+    maxVideoBitrate: sanitizeMaxVideoBitrate(properties.maxVideoBitrate),
     videoBitratePreset: sanitizeVideoBitratePreset(
       properties.videoBitratePreset,
       properties.maxVideoBitrate

--- a/src/helpers/OTSessionHelper.js
+++ b/src/helpers/OTSessionHelper.js
@@ -27,7 +27,10 @@ const setIsConnected = (sessionId, value) => {
 };
 
 const addStream = (sessionId, streamId) => {
-  if (streams[sessionId] && !streams[sessionId].includes(streamId)) {
+  if (!streams[sessionId]) {
+    streams[sessionId] = [];
+  }
+  if (!streams[sessionId].includes(streamId)) {
     streams[sessionId].push(streamId);
   }
 };


### PR DESCRIPTION
Fixes #176
Fixes #177

## Two JS-helper correctness bugs

**#176 — `maxVideoBitrate` silently ignored.** `sanitizeProperties` fed `properties.videoBitratePreset` (a string) to `sanitizeMaxVideoBitrate` (which expects a number and returns `0` otherwise), so the publisher's bitrate cap was always `0` / ignored.

```diff
- maxVideoBitrate: sanitizeMaxVideoBitrate(properties.videoBitratePreset),
+ maxVideoBitrate: sanitizeMaxVideoBitrate(properties.maxVideoBitrate),
```

**#177 — first stream of a session dropped.** `addStream` only pushed when `streams[sessionId]` already existed, but it was never initialized, so the first `streamCreated` per session was lost. Initialize it before pushing (mirrors `removeStream`'s guard).

## Verification (negative + positive control)

Added regression tests in `OTPublisherHelper.test.js` / `OTSessionHelper.test.js`:

- **Negative control** — on the unfixed code the two new tests **fail** (`maxVideoBitrate` → 0; `getStreams` → `[]`): `Tests: 2 failed, 4 passed`.
- **Positive control** — with the fix: `Tests: 6 passed, 6 total`.

`lint` + `types` pass (pre-commit hook).

## Branch coverage
Both bugs are **identical on `develop` and `chore/upgrade-rn-0.86`** — this patch applies verbatim to both; the 0.86 upgrade branch inherits it on rebase.
